### PR TITLE
Removing attributes inside evaluators.

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
@@ -535,11 +535,20 @@ public class Constituent implements Serializable {
         this.incomingRelations.clear();
     }
 
-    public void removeOutgoingRelaton(Relation r) {
+    public void removeOutgoingRelation(Relation r) {
         this.outgoingRelations.remove(r);
     }
 
     public void removeAllOutgoingRelaton() {
         this.outgoingRelations.clear();
     }
+
+    /**
+      * Removes all attributes from a Constituent.
+      */
+    public void removeAllAttributes() {
+        this.attributes = null;
+    }
 }
+
+

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/View.java
@@ -257,6 +257,14 @@ public class View implements Serializable, IQueryable<Constituent> {
     }
 
     /**
+     * Removes all the attributes from the constituents of this of this view
+     */
+    public void removeAttributes() {
+        for(Constituent cons : constituents)
+        cons.removeAllAttributes();
+    }
+
+    /**
      * Checks if this view contains a constituent
      *
      * @param c The constituent, whose containership needs to be checked.

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentLabelingEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentLabelingEvaluator.java
@@ -19,15 +19,8 @@ import java.util.Set;
 
 public class ConstituentLabelingEvaluator extends Evaluator {
 
-    View gold, prediction;
-
-    public void setViews(View gold, View prediction) {
-        this.gold = gold;
-        this.prediction = prediction;
-    }
-
-    public void evaluate(ClassificationTester tester) {
-
+    public void evaluate(ClassificationTester tester, View gold, View prediction) {
+        super.cleanAttributes(gold, prediction);
         Set<Constituent> goldCons = new HashSet<>(gold.getConstituents());
         Set<Constituent> predictionCons = new HashSet<>(prediction.getConstituents());
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentSpanSplittingEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentSpanSplittingEvaluator.java
@@ -19,15 +19,8 @@ import java.util.Set;
 
 public class ConstituentSpanSplittingEvaluator extends Evaluator {
 
-    View gold, prediction;
-
-    public void setViews(View gold, View prediction) {
-        this.gold = gold;
-        this.prediction = prediction;
-    }
-
-    public void evaluate(ClassificationTester tester) {
-
+    public void evaluate(ClassificationTester tester, View gold, View prediction) {
+        super.cleanAttributes(gold, prediction);
         Set<IntPair> goldSpans = new HashSet<>();
         for (Constituent cons : gold.getConstituents()) {
             goldSpans.add(cons.getSpan());

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefAccuracyEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefAccuracyEvaluator.java
@@ -23,17 +23,13 @@ import java.util.List;
  * in the same cluster both in the gold clustering and prediction clustering
  */
 public class CorefAccuracyEvaluator extends Evaluator {
-    CoreferenceView gold, prediction;
-
-    public void setViews(View gold, View prediction) {
-        this.gold = (CoreferenceView) gold;
-        this.prediction = (CoreferenceView) prediction;
-    }
-
-    public void evaluate(ClassificationTester tester) {
+    public void evaluate(ClassificationTester tester, View goldView, View predictionView) {
+        super.cleanAttributes(goldView, predictionView);
         int overlapCount = 0;
         int predCount = 0;
         int goldCount = 0;
+        CoreferenceView gold = (CoreferenceView)goldView;
+        CoreferenceView prediction = (CoreferenceView)predictionView;
         List<Constituent> allGoldConstituents = gold.getConstituents();
         for(Constituent cons1 : allGoldConstituents) {
             HashSet<Constituent> conferents1gold = gold.getOverlappingChainsCanonicalMentions(cons1);

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefBCubedEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefBCubedEvaluator.java
@@ -51,16 +51,14 @@ import java.util.Set;
 public class CorefBCubedEvaluator extends Evaluator {
     CoreferenceView gold, prediction;
 
-    public void setViews(View gold, View prediction) {
-        this.gold = (CoreferenceView) gold;
-        this.prediction = (CoreferenceView) prediction;
-    }
-
     /**
      * The result will be populated in a ClassificationTester. Note that you can either use "micro" or "macro" statistics.
      * It is more common to use "macro" statistics for BCubed metric.
      */
-    public void evaluate(ClassificationTester tester) {
+    public void evaluate(ClassificationTester tester, View goldView, View predictionView) {
+        super.cleanAttributes(goldView, predictionView);
+        this.gold = (CoreferenceView) goldView;
+        this.prediction = (CoreferenceView) predictionView;
         List<Constituent> allGoldConstituents = gold.getConstituents();
         for(Constituent cons : allGoldConstituents) {
             HashSet<Constituent> overlappingGoldCanonicalCons = gold.getOverlappingChainsCanonicalMentions(cons);

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefMUCEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefMUCEvaluator.java
@@ -30,12 +30,10 @@ import java.util.Set;
 public class CorefMUCEvaluator extends Evaluator {
     CoreferenceView gold, prediction;
 
-    public void setViews(View gold, View prediction) {
-        this.gold = (CoreferenceView) gold;
-        this.prediction = (CoreferenceView) prediction;
-    }
-
-    public void evaluate(ClassificationTester tester) {
+    public void evaluate(ClassificationTester tester, View goldView, View predictionView) {
+        super.cleanAttributes(goldView, predictionView);
+        this.gold = (CoreferenceView) goldView;
+        this.prediction = (CoreferenceView) predictionView;
         // Recall = \sum_i [ |si| - |pOfsi| ] / \sum_i [ |si| - 1 ]
         // where si is a true cluster, pOfsi is the set of predicted
         // clusters that contain elements of si (i.e. number of predicted clusters having some overlap with

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/Evaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/Evaluator.java
@@ -14,7 +14,10 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.core.experiments.ClassificationTester;
 
 public abstract class Evaluator {
-    public abstract void setViews(View goldView, View predictedView);
-
-    public abstract void evaluate(ClassificationTester senseTester);
+    protected void cleanAttributes(View gold, View prediction) {
+        // get rid of attributes
+        gold.removeAttributes();
+        prediction.removeAttributes();
+    }
+    public abstract void evaluate(ClassificationTester senseTester, View goldView, View predictedView);
 }

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluator.java
@@ -29,7 +29,6 @@ public class PredicateArgumentEvaluator extends Evaluator {
     Map<Constituent, Constituent> goldToPredictionPredicateMapping;
 
     public void evaluateSense(ClassificationTester senseTester, View goldView, View predictionView) {
-        super.cleanAttributes(goldView, predictionView);
         gold = (PredicateArgumentView)goldView;
         prediction = (PredicateArgumentView)predictionView;
         goldToPredictionPredicateMapping = getGoldToPredictionPredicateMapping();

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluator.java
@@ -28,13 +28,11 @@ public class PredicateArgumentEvaluator extends Evaluator {
     PredicateArgumentView gold, prediction;
     Map<Constituent, Constituent> goldToPredictionPredicateMapping;
 
-    public void setViews(View gold, View prediction) {
-        this.gold = (PredicateArgumentView) gold;
-        this.prediction = (PredicateArgumentView) prediction;
+    public void evaluateSense(ClassificationTester senseTester, View goldView, View predictionView) {
+        super.cleanAttributes(goldView, predictionView);
+        gold = (PredicateArgumentView)goldView;
+        prediction = (PredicateArgumentView)predictionView;
         goldToPredictionPredicateMapping = getGoldToPredictionPredicateMapping();
-    }
-
-    public void evaluateSense(ClassificationTester senseTester) {
         for (Constituent gp : gold.getPredicates()) {
             if (goldToPredictionPredicateMapping.containsKey(gp)) {
                 Constituent pp = goldToPredictionPredicateMapping.get(gp);
@@ -58,7 +56,11 @@ public class PredicateArgumentEvaluator extends Evaluator {
      *
      * @param tester The multi-class {@link ClassificationTester} for the argument labels
      */
-    public void evaluate(ClassificationTester tester) {
+    public void evaluate(ClassificationTester tester, View goldView, View predictionView) {
+        super.cleanAttributes(goldView, predictionView);
+        gold = (PredicateArgumentView)goldView;
+        prediction = (PredicateArgumentView)predictionView;
+        goldToPredictionPredicateMapping = getGoldToPredictionPredicateMapping();
         for (Constituent gp : gold.getPredicates()) {
             if (!goldToPredictionPredicateMapping.containsKey(gp)) {
                 // if there is no matching prediction, then, we have a recall

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentLabelingEvaluatorTest.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentLabelingEvaluatorTest.java
@@ -40,8 +40,7 @@ public class ConstituentLabelingEvaluatorTest {
     @Test
     public void testEvaluateIdenticalSpanLabels() throws Exception {
         ConstituentLabelingEvaluator evaluator = new ConstituentLabelingEvaluator();
-        evaluator.setViews(gold, gold);
-        evaluator.evaluate(splittingTester);
+        evaluator.evaluate(splittingTester, gold, gold);
         assertEquals(1.0, splittingTester.getMicroF1(), 0);
         assertEquals(1.0, splittingTester.getMicroPrecision(), 0);
     }
@@ -49,8 +48,7 @@ public class ConstituentLabelingEvaluatorTest {
     @Test
     public void testEvaluateNoisySpanLabels() throws Exception {
         ConstituentLabelingEvaluator evaluator = new ConstituentLabelingEvaluator();
-        evaluator.setViews(gold, predicted);
-        evaluator.evaluate(splittingTester);
+        evaluator.evaluate(splittingTester, gold, predicted);
         assertEquals(splittingTester.getMicroF1(), 0.57, 0.01);
         assertEquals(0.5, splittingTester.getMicroPrecision(), 0);
     }

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentSpanSplittingEvaluatorTest.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/ConstituentSpanSplittingEvaluatorTest.java
@@ -36,8 +36,7 @@ public class ConstituentSpanSplittingEvaluatorTest {
     @Test
     public void testIdenticalSplitting() throws Exception {
         ConstituentSpanSplittingEvaluator evaluator = new ConstituentSpanSplittingEvaluator();
-        evaluator.setViews(prediction1, prediction1);
-        evaluator.evaluate(splittingTester);
+        evaluator.evaluate(splittingTester, prediction1, prediction1);
         assertEquals(1.0, splittingTester.getMicroF1(), 0);
         assertEquals(1.0, splittingTester.getMicroPrecision(), 0);
     }
@@ -45,8 +44,7 @@ public class ConstituentSpanSplittingEvaluatorTest {
     @Test
     public void testShorterPredictionSpans() throws Exception {
         ConstituentSpanSplittingEvaluator evaluator = new ConstituentSpanSplittingEvaluator();
-        evaluator.setViews(prediction1, prediction2);
-        evaluator.evaluate(splittingTester);
+        evaluator.evaluate(splittingTester, prediction1, prediction2);
         assertEquals(0.4, splittingTester.getMicroF1(), 0);
         assertEquals(1.0, splittingTester.getMicroPrecision(), 0);
     }
@@ -54,8 +52,7 @@ public class ConstituentSpanSplittingEvaluatorTest {
     @Test
     public void testLongerPredictionSpans() throws Exception {
         ConstituentSpanSplittingEvaluator evaluator = new ConstituentSpanSplittingEvaluator();
-        evaluator.setViews(prediction2, prediction1);
-        evaluator.evaluate(splittingTester);
+        evaluator.evaluate(splittingTester, prediction2, prediction1);
         assertEquals(0.4, splittingTester.getMicroF1(), 0);
         assertEquals(0.25, splittingTester.getMicroPrecision(), 0);
     }

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefEvaluatorTest.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/CorefEvaluatorTest.java
@@ -31,7 +31,6 @@ import static org.junit.Assert.assertEquals;
 // b3Cluster:  P:   0.75  -  R:  1.0 - F:  0.857
 public class CorefEvaluatorTest {
     CoreferenceView gold, predicted;
-    ClassificationTester senseTester, argLabelTester;
 
     @Before
     public void setUp() throws Exception {
@@ -56,24 +55,21 @@ public class CorefEvaluatorTest {
     public void testScores() throws Exception {
         ClassificationTester mucTester = new ClassificationTester();
         CorefMUCEvaluator mucEvaluator = new CorefMUCEvaluator();
-        mucEvaluator.setViews(gold, predicted);
-        mucEvaluator.evaluate(mucTester);
+        mucEvaluator.evaluate(mucTester, gold, predicted);
         assertEquals(mucTester.getMacroF1(), 0.94, 0.01);
         assertEquals(mucTester.getMacroPrecision(), 0.9, 0.01);
         assertEquals(mucTester.getMacroRecall(), 1.0, 0.01);
 
         ClassificationTester bcubedTester = new ClassificationTester();
         CorefBCubedEvaluator bcubedEvaluator = new CorefBCubedEvaluator();
-        bcubedEvaluator.setViews(gold, predicted);
-        bcubedEvaluator.evaluate(bcubedTester);
+        bcubedEvaluator.evaluate(bcubedTester, gold, predicted);
         assertEquals(bcubedTester.getMacroF1(), 0.73, 0.01);
         assertEquals(bcubedTester.getMacroPrecision(), 0.58, 0.01);
         assertEquals(bcubedTester.getMacroRecall(), 1.0, 0.01);
 
         ClassificationTester accuracyTester = new ClassificationTester();
         CorefAccuracyEvaluator accuracyEvaluator = new CorefAccuracyEvaluator();
-        accuracyEvaluator.setViews(gold, predicted);
-        accuracyEvaluator.evaluate(accuracyTester);
+        accuracyEvaluator.evaluate(accuracyTester, gold, predicted);
         assertEquals(accuracyTester.getMacroF1(), 0.68, 0.01);
         assertEquals(accuracyTester.getMacroPrecision(), 0.51, 0.01);
         assertEquals(accuracyTester.getMacroRecall(), 1.0, 0.01);

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluatorTest.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/experiments/evaluators/PredicateArgumentEvaluatorTest.java
@@ -44,23 +44,20 @@ public class PredicateArgumentEvaluatorTest {
     @Test
     public void testEvaluateSense() throws Exception {
         PredicateArgumentEvaluator evaluator = new PredicateArgumentEvaluator();
-        evaluator.setViews(gold, predicted);
-        evaluator.evaluateSense(senseTester);
+        evaluator.evaluateSense(senseTester, gold, predicted);
         assertEquals(1.0, senseTester.getMicroF1(), 0);
 
         // Override the sense
         predicted.getPredicates().get(0).addAttribute(CoNLLColumnFormatReader.SenseIdentifer, "02");
         evaluator = new PredicateArgumentEvaluator();
-        evaluator.setViews(gold, predicted);
-        evaluator.evaluateSense(senseTester);
+        evaluator.evaluateSense(senseTester, gold, predicted);
         assertEquals(0.5, senseTester.getMicroF1(), 0);
     }
 
     @Test
     public void testEvaluate() throws Exception {
         PredicateArgumentEvaluator evaluator = new PredicateArgumentEvaluator();
-        evaluator.setViews(gold, predicted);
-        evaluator.evaluate(argLabelTester);
+        evaluator.evaluate(argLabelTester, gold, predicted);
         assertEquals(1.0, argLabelTester.getMicroF1(), 0);
 
         // Add a wrong prediction
@@ -69,8 +66,7 @@ public class PredicateArgumentEvaluatorTest {
                 new Constituent("test", ViewNames.SRL_VERB, predicate.getTextAnnotation(), 0, 1);
         predicted.addRelation(new Relation("test", predicate, argument, 0));
         evaluator = new PredicateArgumentEvaluator();
-        evaluator.setViews(gold, predicted);
-        evaluator.evaluate(argLabelTester);
+        evaluator.evaluate(argLabelTester, gold, predicted);
         assertEquals(0.92, argLabelTester.getMicroF1(), 0.1);
     }
 }


### PR DESCRIPTION
The evaluators user to compare the meta information inside constituents, while it should be just label and span information. This makes the evaluators remove the attributes, before the evaluations. 

FYI @joshuacamp @DhruvVajpeyi 