### PR TITLE
Trailing Whitepspace Only

### DIFF
--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefulTokenizer.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefulTokenizer.java
@@ -118,21 +118,22 @@ public class StatefulTokenizer implements Tokenizer {
     			                        " a plant manager making between $90,000 and $120,000 may expect to get a 10 percent raise or more.        \n";
         String issue2 = "John is 'a good boy' and he is 'not a dog' or a dogs' or a dog's eye.";
         String issue3 = "At 1:30 a.m. Sunday, the troops moved out: 40 U.S. soldiers in a convoy of Humvees mounted with heavy machine guns, and 60 Afghan National Army troops in pickup trucks.";
-        String issue4 = "And John said \"There are those who would.\" So ended his reign.";
+        String issue4 = " There is one.     ";
         String issue5 = "\"I said, 'what're you? Crazy?'\" said Sandowsky. \"I can't afford to do that.";
         String [] ss = {issue1, issue2, issue3, issue4, issue5};
         for (String issue : ss) {
-            final TextAnnotationBuilder stab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
-            TextAnnotation ta = stab.createTextAnnotation(issue);
-            System.out.println(ta);
-            for (int i = 0; i < ta.getNumberOfSentences(); i++)
-                System.out.println(ta.getSentence(i));
-    
+        	TextAnnotation ta;
             final TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder(new IllinoisTokenizer());
             ta = tab.createTextAnnotation(issue);
             for (int i = 0; i < ta.getNumberOfSentences(); i++)
                 System.out.println(ta.getSentence(i));
             System.out.println("\n");
+            final TextAnnotationBuilder stab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
+            ta = stab.createTextAnnotation(issue);
+            System.out.println(ta);
+            for (int i = 0; i < ta.getNumberOfSentences(); i++)
+                System.out.println(ta.getSentence(i));
+    
         }
     }
 }

--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
@@ -473,11 +473,23 @@ public class TokenizerStateMachine {
      * @param intext the text to parse.
      */
     protected void parseText(String intext) {
+    	// find index of last non whitespace
+    	int i = intext.length()-1;
+    	for (; i >=0 ; i--) {
+    		if (!Character.isWhitespace(intext.charAt(i)))
+    			break; // found the first non-whitepsace.
+    	}
+    	i++; // length is one beyond the last whitespace char.
+        stack = new ArrayList<State>();
+        completed = new ArrayList<State>();
+    	if (i == 0)
+    		return;
+    	this.text = new char[i];
+    	intext.getChars(0, i, this.text, 0);
+    	
         this.textstring = intext.trim();
         this.text = this.textstring.toCharArray();
         current = 0;
-        stack = new ArrayList<State>();
-        completed = new ArrayList<State>();
         this.push(new State(TokenizerState.IN_SENTENCE), current);
         for (current = 0; current < this.text.length; current++) {
             char character = this.text[current];


### PR DESCRIPTION
Now removes white space characters only from the end of the string before parsing. Removing from the beginning of the string will change
character offsets which is bad.