### PR TITLE
Fixed bug in feature manifest

### DIFF
--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/manifest/FeatureManifest.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/manifest/FeatureManifest.java
@@ -523,6 +523,7 @@ public class FeatureManifest {
 
     private List<String> getUniqueList(Tree<String> tree) {
         List<String> f = new ArrayList<>();
+        f.add(tree.getLabel());
         for (Tree<String> child : tree.getChildren()) {
             f.add(child.toString().replaceAll("\\s+", " "));
         }


### PR DESCRIPTION
Adding the label of the current node to the description list.
Closes #55