### PR TITLE
Fixed H2 DBHelper error

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/io/caches/DBHelper.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/io/caches/DBHelper.java
@@ -77,7 +77,7 @@ public class DBHelper {
 
     public static boolean dbFileExists(String dbFile) {
         boolean create = false;
-        if (!IOUtils.exists(dbFile + ".h2.db"))
+        if (!IOUtils.exists(dbFile + ".h2.db") && !IOUtils.exists(dbFile + ".mv.db"))
             create = true;
         return create;
     }


### PR DESCRIPTION
New version of H2 will create a `.mv.db` file instead of the old `.h2.db`