### PR TITLE
added simple fix for NER random label generator. If only one label is…

### DIFF
--- a/ner/src/main/java/edu/illinois/cs/cogcomp/ner/LbjTagger/RandomLabelGenerator.java
+++ b/ner/src/main/java/edu/illinois/cs/cogcomp/ner/LbjTagger/RandomLabelGenerator.java
@@ -10,12 +10,16 @@
  */
 package edu.illinois.cs.cogcomp.ner.LbjTagger;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Random;
 
 /**
  * A class to generate random labels...
  */
 public class RandomLabelGenerator {
+    private Logger logger = LoggerFactory.getLogger( RandomLabelGenerator.class );
     private String[] labelTypes = null; // will be initialized to something like:
                                         // {"O","PER","ORG","LOC","MISC"};
     private String[] labelNames = null; // will be initialized to something like:
@@ -28,7 +32,16 @@ public class RandomLabelGenerator {
 
     public RandomLabelGenerator(String[] _labelTypes,
             TextChunkRepresentationManager.EncodingScheme encodingScheme, double noiseLevel) {
+
         this.noiseLevel = noiseLevel;
+
+        if ( _labelTypes.length == 1 && noiseLevel > 0. )
+        {
+            logger.warn( "ERROR: only one label has been specified and noise level is non-zero. " +
+                    "setting noise level to zero." );
+            this.noiseLevel = 0;
+        }
+
         rand = new Random(randomizationSeed);
         labelTypes = new String[_labelTypes.length + 1];
         labelTypes[0] = "O";

--- a/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NERAnnotatorTest.java
+++ b/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NERAnnotatorTest.java
@@ -11,15 +11,15 @@
 package edu.illinois.cs.cogcomp.ner;
 
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 
+import edu.illinois.cs.cogcomp.core.utilities.configuration.Property;
+import edu.illinois.cs.cogcomp.ner.LbjTagger.RandomLabelGenerator;
+import edu.illinois.cs.cogcomp.ner.LbjTagger.TextChunkRepresentationManager;
+import edu.illinois.cs.cogcomp.ner.config.NerBaseConfigurator;
 import edu.illinois.cs.cogcomp.nlp.utility.TokenizerTextAnnotationBuilder;
 import org.junit.Test;
 
@@ -31,6 +31,8 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.nlp.tokenizer.IllinoisTokenizer;
 import weka.core.Debug.Random;
+
+import static org.junit.Assert.*;
 
 /**
  * This tests the NERAnnotator. Includes a test to ensure we are extracting the expected entiies,
@@ -350,5 +352,19 @@ public class NERAnnotatorTest {
     public static View getView(TextAnnotation ta) {
         nerAnnotator.addView(ta);
         return ta.getView(nerAnnotator.getViewName());
+    }
+
+    /**
+     * Test for corner case where user specifies a single label and non-zero noise level.
+     *
+     */
+    @Test
+    public void testSingleLabelNoise()
+    {
+        String[] labels = new String[]{ "PER" };
+        RandomLabelGenerator rlg =
+                new RandomLabelGenerator( labels, TextChunkRepresentationManager.EncodingScheme.BILOU, 2.0 );
+        for( int i = 0; i < 1000; ++i )
+           assertFalse( rlg.useNoise() );
     }
 }


### PR DESCRIPTION
… specified, noise level is set to zero and a warning is logged.

Added a test in NerAnnotatorTest (testSingleLabelNoise)
addresses #121 