### PR TITLE
Fixed several errors in 2 LREC feature extractors/tests

### DIFF
--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/PosWordConjunctionSizeTwoWindowSizeTwo.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/PosWordConjunctionSizeTwoWindowSizeTwo.java
@@ -37,6 +37,15 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
         this.viewName = viewName;
     }
 
+    /**
+     * Extracts an array of tokens from a uniform window of size k
+     *
+     * @param TOKENS    The tokens {@link View} of the {@link TextAnnotation} object
+     * @param startspan The span at the beginning of the {@link Constituent} object
+     * @param endspan   The span at the end of the {@link Constituent} object
+     * @param k         The number of tokens to the left and right of the current {@link Constituent} object to get
+     * @return The window of k tokens to the left and k tokens to the right of the current {@link Constituent} object
+     */
     private String[] getWindowK(View TOKENS, int startspan, int endspan, int k) {
         String window[] = new String[2 * k + 1];
 
@@ -54,11 +63,19 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
         for (int i = startwin; i < endwin; i++) {
             window[index] = TOKENS.getConstituentsCoveringSpan(i, i + 1).get(0).getSurfaceForm();
             index++;
-
         }
         return window;
     }
 
+    /**
+     * Extracts an array of POS-tags from a uniform window of size k
+     *
+     * @param POS       The part-of-speech {@link View} of the {@link TextAnnotation} object
+     * @param startspan The span at the beginning of the {@link Constituent} object
+     * @param endspan   The span at the end of the {@link Constituent} object
+     * @param k         The number of tokens to the left and right of the current {@link Constituent} object to get
+     * @return The window of k POS-tags to the left and k tokens to the right of the current {@link Constituent} object
+     */
     private String[] getWindowKTags(View POS, int startspan, int endspan, int k) {
         String tags[] = new String[2 * k + 1];
 
@@ -88,7 +105,6 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
      *
      **/
     public Set<Feature> getFeatures(Constituent c) throws EdisonException {
-
         TextAnnotation ta = c.getTextAnnotation();
 
         View TOKENS = null, POS = null;
@@ -127,13 +143,12 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
                     f.append("-");
                     f.append(forms[i + context]);
                 }
-                // 2 is the center object in the array so i should go from -2 to +2
+                // 2 is the center object in the array so i should go from -2 to +2 (with 0 being the center)
                 // j is the size of the n-gram so it goes 1 to 2
                 id = classifier + ":" + ((i - window) + "_" + (j + 1));
                 value = "(" + (f.toString()) + ")";
                 result.add(new DiscreteFeature(id + value));
             }
-
         }
         return result;
     }

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/PosWordConjunctionSizeTwoWindowSizeTwo.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/PosWordConjunctionSizeTwoWindowSizeTwo.java
@@ -12,29 +12,22 @@ package edu.illinois.cs.cogcomp.edison.features.lrec;
 
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Queries;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.edison.features.DiscreteFeature;
 import edu.illinois.cs.cogcomp.edison.features.Feature;
 import edu.illinois.cs.cogcomp.edison.features.FeatureExtractor;
-import edu.illinois.cs.cogcomp.edison.features.RealFeature;
-import edu.illinois.cs.cogcomp.edison.features.helpers.SpanLabelsHelper;
 import edu.illinois.cs.cogcomp.edison.utilities.EdisonException;
 
-import java.util.*;
-
-import java.io.File;
-import java.io.FileWriter;
-import java.io.BufferedWriter;
-import java.io.IOException;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
+ * Extracts the POS Tags as well as the form (text) of tokens 2 before and 2 after from
+ * the given token and generates a discrete feature from it.
  *
- * @author Paul Vijayakumar, Mazin Bokhari Extracts the POS Tags as well as the form (text) of
- *         tokens 2 before and 2 after from the given token and generates a discrete feature from
- *         it.
- *
+ * @keywords pos-tagger, words, tokens, window
+ * @author Paul Vijayakumar, Mazin Bokhari, Christos Christodoulopoulos
  */
 public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor {
 
@@ -44,8 +37,7 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
         this.viewName = viewName;
     }
 
-    public String[] getwindowkfrom(View TOKENS, int startspan, int endspan, int k) {
-
+    private String[] getwindowkfrom(View TOKENS, int startspan, int endspan, int k) {
         String window[] = new String[2 * k + 1];
 
         int startwin = startspan - k;
@@ -58,32 +50,32 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
             startwin = 0;
         }
 
+        int index = 0;
         for (int i = startwin; i < endwin; i++) {
-
-            window[i] = TOKENS.getConstituentsCoveringSpan(i, i + 1).get(0).getSurfaceForm();
+            window[index] = TOKENS.getConstituentsCoveringSpan(i, i + 1).get(0).getSurfaceForm();
+            index++;
 
         }
         return window;
     }
 
-    public String[] getwindowtagskfrom(View TOKENS, View POS, int startspan, int endspan, int k) {
-
+    private String[] getwindowtagskfrom(View POS, int startspan, int endspan, int k) {
         String tags[] = new String[2 * k + 1];
 
         int startwin = startspan - k;
         int endwin = endspan + k;
 
-        if (endwin > TOKENS.getEndSpan()) {
-            endwin = TOKENS.getEndSpan();
+        if (endwin > POS.getEndSpan()) {
+            endwin = POS.getEndSpan();
         }
         if (startwin < 0) {
             startwin = 0;
         }
 
+        int index = 0;
         for (int i = startwin; i < endwin; i++) {
-
-            tags[i] = POS.getLabelsCoveringSpan(i, i + 1).get(0);
-
+            tags[index] = POS.getLabelsCoveringSpan(i, i + 1).get(0);
+            index++;
         }
         return tags;
     }
@@ -115,39 +107,35 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
 
         // All our constituents are words(tokens)
         int k = 2; // words two before & after
+        int window = 2;
 
         String[] forms = getwindowkfrom(TOKENS, startspan, endspan, k);
-        String[] tags = getwindowtagskfrom(TOKENS, POS, startspan, endspan, k);
+        String[] tags = getwindowtagskfrom(POS, startspan, endspan, k);
 
         String classifier = "PosWordConjunctionSizeTwoWindowSizeTwo";
-        String __id, __value;
-        Set<Feature> __result = new LinkedHashSet<Feature>();
+        String id, value;
+        Set<Feature> result = new LinkedHashSet<>();
 
-        int maxcontext = 2;
-
-        for (int j = 1; j < maxcontext; j++) {
-            for (int x = 0; x < 2; x++) {
-                boolean t = true;
-                for (int i = 0; i < tags.length; i++) {
-                    StringBuffer f = new StringBuffer();
-                    for (int context = 0; context <= j && i + context < tags.length; context++) {
-                        if (context != 0) {
-                            f.append("_");
-                        }
-                        if (t && x == 0) {
-                            f.append(tags[i + context]);
-                        } else {
-                            f.append(forms[i + context]);
-                        }
-                        t = !t;
+        for (int j = 0; j < k; j++) {
+            for (int i = 0; i < tags.length; i++) {
+                StringBuilder f = new StringBuilder();
+                for (int context = 0; context <= j && i + context < tags.length; context++) {
+                    if (context != 0) {
+                        f.append("_");
                     }
-                    __id = classifier + ":" + (i + "_" + j);
-                    __value = "(" + (f.toString()) + ")";
-                    __result.add(new DiscreteFeature(__id + __value));
+                    f.append(tags[i + context]);
+                    f.append("-");
+                    f.append(forms[i + context]);
                 }
+                // 2 is the center object in the array so i should go from -2 to +2
+                // j is the size of the n-gram so it goes 1 to 2
+                id = classifier + ":" + ((i - window) + "_" + (j + 1));
+                value = "(" + (f.toString()) + ")";
+                result.add(new DiscreteFeature(id + value));
             }
+
         }
-        return __result;
+        return result;
     }
 
     @Override

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/PosWordConjunctionSizeTwoWindowSizeTwo.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/PosWordConjunctionSizeTwoWindowSizeTwo.java
@@ -37,7 +37,7 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
         this.viewName = viewName;
     }
 
-    private String[] getwindowkfrom(View TOKENS, int startspan, int endspan, int k) {
+    private String[] getWindowK(View TOKENS, int startspan, int endspan, int k) {
         String window[] = new String[2 * k + 1];
 
         int startwin = startspan - k;
@@ -59,7 +59,7 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
         return window;
     }
 
-    private String[] getwindowtagskfrom(View POS, int startspan, int endspan, int k) {
+    private String[] getWindowKTags(View POS, int startspan, int endspan, int k) {
         String tags[] = new String[2 * k + 1];
 
         int startwin = startspan - k;
@@ -109,8 +109,8 @@ public class PosWordConjunctionSizeTwoWindowSizeTwo implements FeatureExtractor 
         int k = 2; // words two before & after
         int window = 2;
 
-        String[] forms = getwindowkfrom(TOKENS, startspan, endspan, k);
-        String[] tags = getwindowtagskfrom(POS, startspan, endspan, k);
+        String[] forms = getWindowK(TOKENS, startspan, endspan, k);
+        String[] tags = getWindowKTags(POS, startspan, endspan, k);
 
         String classifier = "PosWordConjunctionSizeTwoWindowSizeTwo";
         String id, value;

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/WordConjunctionOneTwoThreeGramWindowTwo.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/WordConjunctionOneTwoThreeGramWindowTwo.java
@@ -23,7 +23,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
- * Extracts the k Tokens to the left and k Tokens to the right of the Constituent object.
+ * Extracts the k tokens to the left and k tokens to the right of the {@link Constituent} object.
  * Generates a conjunction of 3-shingles from a window of 2 tokens.
  *
  * @keywords chunker, shallow-parser, pos-tagger, words, tokens, window, trigram
@@ -41,15 +41,14 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
     }
 
     /**
+     * Extracts an array of tokens from a uniform window of size k
      *
-     * @param TOKENS The Tokens View of the TextAnnotation object
-     * @param startspan The span at the beginning of the Constituent object
-     * @param endspan The span at the end of the Constituent object
-     * @param k The number of Tokens to the left and right of the current Constituent object to get
-     * @return Return the window of k Tokens to the left and k Tokens to the right of the current
-     *         Constituent object
+     * @param TOKENS    The tokens {@link View} of the {@link TextAnnotation} object
+     * @param startspan The span at the beginning of the {@link Constituent} object
+     * @param endspan   The span at the end of the {@link Constituent} object
+     * @param k         The number of tokens to the left and right of the current {@link Constituent} object to get
+     * @return The window of k tokens to the left and k tokens to the right of the current {@link Constituent} object
      */
-
     private String[] getWindowK(View TOKENS, int startspan, int endspan, int k) {
         String window[] = new String[2 * k + 1];
 
@@ -78,7 +77,6 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
      *
      **/
     public Set<Feature> getFeatures(Constituent c) throws EdisonException {
-
         TextAnnotation ta = c.getTextAnnotation();
         TOKENS = ta.getView(ViewNames.TOKENS);
 
@@ -88,7 +86,6 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
         // k is 3 since we need up to 3-grams
         int k = 3;
         int window = 2;
-
 
         // All our constituents are words(tokens)
         String[] forms = getWindowK(TOKENS, startspan, endspan, window);
@@ -117,14 +114,13 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
                     f.append(forms[i + context]);
                 }
 
-                // 2 is the center object in the array so i should go from -2 to +2
+                // 2 is the center object in the array so i should go from -2 to +2 (with 0 being the center)
                 // j is the size of the n-gram so it goes 1 to 3
                 id = classifier + ":" + ((i - window) + "_" + (j + 1));
                 value = "(" + (f.toString()) + ")";
                 result.add(new DiscreteFeature(id + value));
             }
         }
-
         return result;
     }
 

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/WordConjunctionOneTwoThreeGramWindowTwo.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/WordConjunctionOneTwoThreeGramWindowTwo.java
@@ -50,7 +50,7 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
      *         Constituent object
      */
 
-    private String[] getWindowKFrom(View TOKENS, int startspan, int endspan, int k) {
+    private String[] getWindowK(View TOKENS, int startspan, int endspan, int k) {
         String window[] = new String[2 * k + 1];
 
         int startwin = startspan - k;
@@ -91,7 +91,7 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
 
 
         // All our constituents are words(tokens)
-        String[] forms = getWindowKFrom(TOKENS, startspan, endspan, window);
+        String[] forms = getWindowK(TOKENS, startspan, endspan, window);
 
         String id, value;
         String classifier = "WordConjunctionOneTwoThreeGramWindowTwo";

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/WordConjunctionOneTwoThreeGramWindowTwo.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/lrec/WordConjunctionOneTwoThreeGramWindowTwo.java
@@ -12,24 +12,22 @@ package edu.illinois.cs.cogcomp.edison.features.lrec;
 
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Queries;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.edison.features.DiscreteFeature;
 import edu.illinois.cs.cogcomp.edison.features.Feature;
 import edu.illinois.cs.cogcomp.edison.features.FeatureExtractor;
-import edu.illinois.cs.cogcomp.edison.features.RealFeature;
-import edu.illinois.cs.cogcomp.edison.features.helpers.SpanLabelsHelper;
 import edu.illinois.cs.cogcomp.edison.utilities.EdisonException;
 
-import java.util.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 /**
+ * Extracts the k Tokens to the left and k Tokens to the right of the Constituent object.
+ * Generates a conjunction of 3-shingles from a window of 2 tokens.
  *
- * @author Paul Vijayakumar, Mazin Bokhari Extracts the k Tokens to the left and k Tokens to the
- *         right of the Constituent object. Generates a conjunction of 3-shingles from a window of 2
- *         tokens.
- *
+ * @keywords chunker, shallow-parser, pos-tagger, words, tokens, window, trigram
+ * @author Paul Vijayakumar, Mazin Bokhari, Christos Christodoulopoulos
  */
 public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor {
 
@@ -52,8 +50,7 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
      *         Constituent object
      */
 
-    public String[] getWindowKFrom(View TOKENS, int startspan, int endspan, int k) {
-
+    private String[] getWindowKFrom(View TOKENS, int startspan, int endspan, int k) {
         String window[] = new String[2 * k + 1];
 
         int startwin = startspan - k;
@@ -66,10 +63,10 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
             startwin = 0;
         }
 
+        int index = 0;
         for (int i = startwin; i < endwin; i++) {
-
-            window[i] = TOKENS.getConstituentsCoveringSpan(i, i + 1).get(0).getSurfaceForm();
-
+            window[index] = TOKENS.getConstituentsCoveringSpan(i, i + 1).get(0).getSurfaceForm();
+            index++;
         }
         return window;
     }
@@ -85,36 +82,34 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
         TextAnnotation ta = c.getTextAnnotation();
         TOKENS = ta.getView(ViewNames.TOKENS);
 
-        // We can assume that the constituent in this case is a Word(Token) described by the LBJ
-        // chunk definition
-
+        // We can assume that the constituent in this case is a Word(Token)
         int startspan = c.getStartSpan();
         int endspan = c.getEndSpan();
-        int k = 2;
+        // k is 3 since we need up to 3-grams
+        int k = 3;
+        int window = 2;
 
 
         // All our constituents are words(tokens)
-        String[] forms = getWindowKFrom(TOKENS, startspan, endspan, 2);
+        String[] forms = getWindowKFrom(TOKENS, startspan, endspan, window);
 
-        String __id, __value;
+        String id, value;
         String classifier = "WordConjunctionOneTwoThreeGramWindowTwo";
-        Set<Feature> __result = new LinkedHashSet<Feature>();
+        Set<Feature> result = new LinkedHashSet<>();
 
         for (int j = 0; j < k; j++) {
-            // k = 2, j goes from 0 to 1
+            // k = 3, j goes from 0 to 2
 
             for (int i = 0; i < forms.length; i++) {
-                // forms.length = 5, So i goes from 0 to 4, for each String
-                // in the forms array.
+                // forms.length = 5, So i goes from 0 to 4, for each String in the forms array.
 
-                StringBuffer f = new StringBuffer();
+                StringBuilder f = new StringBuilder();
 
                 // Starts with context = 0 and then increments context as long as it is below
                 // the current value of j and is not out of index of the forms array.
                 // This is basically creating a discrete feature for each combination of one, two
                 // and three word combinations within [-2,2] window or words.
                 for (int context = 0; context <= j && i + context < forms.length; context++) {
-
                     // add a '_' between words to conjoin them together
                     if (context != 0) {
                         f.append("_");
@@ -122,13 +117,15 @@ public class WordConjunctionOneTwoThreeGramWindowTwo implements FeatureExtractor
                     f.append(forms[i + context]);
                 }
 
-                __id = classifier + ":" + (i + "_" + j);
-                __value = "(" + (f.toString()) + ")";
-                __result.add(new DiscreteFeature(__id + __value));
+                // 2 is the center object in the array so i should go from -2 to +2
+                // j is the size of the n-gram so it goes 1 to 3
+                id = classifier + ":" + ((i - window) + "_" + (j + 1));
+                value = "(" + (f.toString()) + ")";
+                result.add(new DiscreteFeature(id + value));
             }
         }
 
-        return __result;
+        return result;
     }
 
     @Override

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestPosWordConjunctionSizeTwoWindowSizeTwo.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestPosWordConjunctionSizeTwoWindowSizeTwo.java
@@ -27,7 +27,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test class for SHALLOW PARSER Formpp Feature Extractor
+ * Unit test for {@link PosWordConjunctionSizeTwoWindowSizeTwo} extractor, which generates a conjunction of 2-shingles
+ * from a window of 2 tokens. The extractor is originally used in illinois-chunker (shallow parser).
  *
  * @author Christos Christodoulopoulos
  */

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestPosWordConjunctionSizeTwoWindowSizeTwo.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestPosWordConjunctionSizeTwoWindowSizeTwo.java
@@ -10,111 +10,61 @@
  */
 package edu.illinois.cs.cogcomp.edison.features.lrec;
 
-import org.apache.commons.lang.ArrayUtils;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.PredicateArgumentView;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Relation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
-import edu.illinois.cs.cogcomp.core.io.IOUtils;
-import edu.illinois.cs.cogcomp.edison.features.FeatureCollection;
-import edu.illinois.cs.cogcomp.edison.features.FeatureExtractor;
-import edu.illinois.cs.cogcomp.edison.features.FeatureUtilities;
+import edu.illinois.cs.cogcomp.core.utilities.DummyTextAnnotationGenerator;
 import edu.illinois.cs.cogcomp.edison.features.Feature;
-import edu.illinois.cs.cogcomp.edison.utilities.CreateTestFeaturesResource;
-import edu.illinois.cs.cogcomp.edison.utilities.CreateTestTAResource;
 import edu.illinois.cs.cogcomp.edison.utilities.EdisonException;
-import junit.framework.TestCase;
+import org.apache.commons.lang.ArrayUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.List;
 import java.util.Set;
-import java.util.Random;
-import java.io.Writer;
 
-import org.apache.log4j.Logger;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test class for SHALLOW PARSER Formpp Feature Extractor
  *
- * @author Paul Vijayakumar, Mazin Bokhari
+ * @author Christos Christodoulopoulos
  */
-public class TestPosWordConjunctionSizeTwoWindowSizeTwo extends TestCase {
-    static Logger log = Logger
-            .getLogger(TestPosWordConjunctionSizeTwoWindowSizeTwo.class.getName());
+public class TestPosWordConjunctionSizeTwoWindowSizeTwo {
+    private TextAnnotation ta;
 
-    private static List<TextAnnotation> tas;
-
-    static {
-        try {
-            tas =
-                    IOUtils.readObjectAsResource(TestPosWordConjunctionSizeTwoWindowSizeTwo.class,
-                            "test.ta");
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    @Before
+    public void setUp() throws Exception {
+        ta = DummyTextAnnotationGenerator.generateAnnotatedTextAnnotation(new String[]{ViewNames.POS}, false);
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
+    @Test
     public final void test() throws EdisonException {
+        /// Using the 3rd constituent as a test
+        List<Constituent> testList = ta.getView("TOKENS").getConstituents();
+        Constituent test = testList.get(3);
 
-        log.debug("PosWordConjunctionSizeTwoWindowSizeTwo Feature Extractor");
-        // Using the first TA and a constituent between span of 30-40 as a test
-        TextAnnotation ta = tas.get(1);
-        View TOKENS = ta.getView("TOKENS");
+        PosWordConjunctionSizeTwoWindowSizeTwo fex = new PosWordConjunctionSizeTwoWindowSizeTwo("PosWordConj2Win2");
 
-        log.debug("GOT TOKENS FROM TEXTAnn");
-
-        List<Constituent> testlist = TOKENS.getConstituentsCoveringSpan(0, 20);
-
-        for (Constituent c : testlist) {
-            log.debug(c.getSurfaceForm());
-        }
-
-        log.debug("Testlist size is " + testlist.size());
-
-        Constituent test = testlist.get(1);
-
-        log.debug("The constituent we are extracting features from in this test is: "
-                + test.getSurfaceForm());
-
-        PosWordConjunctionSizeTwoWindowSizeTwo M =
-                new PosWordConjunctionSizeTwoWindowSizeTwo("PosWordConjunctionSizeTwoWindowSizeTwo");
-
-        log.debug("Init Views");
-
-        // Formpp.initViews(test);
-
-        log.debug("Startspan is " + test.getStartSpan() + " and Endspan is " + test.getEndSpan());
-
-        Set<Feature> feats = M.getFeatures(test);
+        Set<Feature> feats = fex.getFeatures(test);
         String[] expected_outputs =
-                {"PosWordConjunctionSizeTwoWindowSizeTwo:0_1(PRP_give)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:1_1(VBP_John)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:2_1(NNP_$900)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:3_1(NN_null)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:4_1(null)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:0_1(I_give)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:1_1(give_John)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:2_1(John_$900)",
-                        "PosWordConjunctionSizeTwoWindowSizeTwo:3_1($900_null)"};
+                {"PosWordConjunctionSizeTwoWindowSizeTwo:-2_1(NN-construction)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:-1_1(IN-of)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:0_1(DT-the)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:1_1(NNP-John)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:2_1(NNP-Smith)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:-2_2(NN-construction_IN-of)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:-1_2(IN-of_DT-the)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:0_2(DT-the_NNP-John)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:1_2(NNP-John_NNP-Smith)",
+                        "PosWordConjunctionSizeTwoWindowSizeTwo:2_2(NNP-Smith)"};
 
 
-        if (feats == null) {
-            log.debug("Feats are returning NULL.");
-        }
+        if (feats == null) fail("Feats are returning NULL.");
 
-        log.debug("Printing Set of Features");
         for (Feature f : feats) {
-            log.debug(f.getName());
-            assert (ArrayUtils.contains(expected_outputs, f.getName()));
+            assertTrue(ArrayUtils.contains(expected_outputs, f.getName()));
         }
-
-        log.debug("GOT FEATURES YES!");
-
-        // System.exit(0);
     }
 }

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestWordConjunctionOneTwoThreeGramWindowTwo.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestWordConjunctionOneTwoThreeGramWindowTwo.java
@@ -27,7 +27,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
- * Test class for SHALLOW PARSER Formpp Feature Extractor
+ * Unit test for {@link WordConjunctionOneTwoThreeGramWindowTwo} extractor, which generates a conjunction of 3-shingles
+ * from a window of 2 tokens. The extractor is originally used in illinois-chunker (shallow parser).
  *
  * @author Christos Christodoulopoulos
  */

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestWordConjunctionOneTwoThreeGramWindowTwo.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/lrec/TestWordConjunctionOneTwoThreeGramWindowTwo.java
@@ -10,109 +10,65 @@
  */
 package edu.illinois.cs.cogcomp.edison.features.lrec;
 
-import org.apache.commons.lang.ArrayUtils;
-import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Constituent;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.PredicateArgumentView;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.Relation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
-import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
-import edu.illinois.cs.cogcomp.core.io.IOUtils;
-import edu.illinois.cs.cogcomp.edison.features.FeatureCollection;
-import edu.illinois.cs.cogcomp.edison.features.FeatureExtractor;
-import edu.illinois.cs.cogcomp.edison.features.FeatureUtilities;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotationUtilities;
+import edu.illinois.cs.cogcomp.core.utilities.DummyTextAnnotationGenerator;
 import edu.illinois.cs.cogcomp.edison.features.Feature;
-import edu.illinois.cs.cogcomp.edison.utilities.CreateTestFeaturesResource;
-import edu.illinois.cs.cogcomp.edison.utilities.CreateTestTAResource;
 import edu.illinois.cs.cogcomp.edison.utilities.EdisonException;
-import junit.framework.TestCase;
+import org.apache.commons.lang.ArrayUtils;
+import org.junit.Before;
+import org.junit.Test;
 
 import java.util.List;
 import java.util.Set;
-import java.util.Random;
-import java.io.Writer;
 
-import org.apache.log4j.Logger;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Test class for SHALLOW PARSER Formpp Feature Extractor
  *
- * @author Paul Vijayakumar, Mazin Bokhari
+ * @author Christos Christodoulopoulos
  */
-public class TestWordConjunctionOneTwoThreeGramWindowTwo extends TestCase {
-    static Logger log = Logger.getLogger(TestAffixes.class.getName());
+public class TestWordConjunctionOneTwoThreeGramWindowTwo {
+    private TextAnnotation ta;
 
-    private static List<TextAnnotation> tas;
-
-    static {
-        try {
-            tas =
-                    IOUtils.readObjectAsResource(TestWordConjunctionOneTwoThreeGramWindowTwo.class,
-                            "test.ta");
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    @Before
+    public void setUp() throws Exception {
+        ta = DummyTextAnnotationGenerator.generateAnnotatedTextAnnotation(new String[]{}, false);
     }
 
-    protected void setUp() throws Exception {
-        super.setUp();
-    }
-
+    @Test
     public final void test() throws EdisonException {
+        // Using the 3rd constituent as a test
+        List<Constituent> testList = ta.getView("TOKENS").getConstituents();
+        Constituent test = testList.get(3);
 
-        log.debug("Formpp");
-        // Using the first TA and a constituent between span of 30-40 as a test
-        TextAnnotation ta = tas.get(1);
-        View TOKENS = ta.getView("TOKENS");
+        WordConjunctionOneTwoThreeGramWindowTwo fex = new WordConjunctionOneTwoThreeGramWindowTwo("WordConj3GramWin2");
 
-        log.debug("GOT TOKENS FROM TEXTAnn");
-
-        List<Constituent> testlist = TOKENS.getConstituentsCoveringSpan(0, 20);
-
-        for (Constituent c : testlist) {
-            log.debug(c.getSurfaceForm());
-        }
-
-        log.debug("Testlist size is " + testlist.size());
-
-        Constituent test = testlist.get(2);
-
-        log.debug("The constituent we are extracting features from in this test is: "
-                + test.getSurfaceForm());
-
-        WordConjunctionOneTwoThreeGramWindowTwo WordConjunctionOneTwoThreeGramWindowTwo =
-                new WordConjunctionOneTwoThreeGramWindowTwo(
-                        "WordConjunctionOneTwoThreeGramWindowTwo");
-
-        log.debug("Startspan is " + test.getStartSpan() + " and Endspan is " + test.getEndSpan());
-
-        Set<Feature> feats = WordConjunctionOneTwoThreeGramWindowTwo.getFeatures(test);
+        Set<Feature> feats = fex.getFeatures(test);
         String[] expected_outputs =
-                {"WordConjunctionOneTwoThreeGramWindowTwo:0_0(I)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:1_0(give)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:2_0(John)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:3_0($900)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:4_0(today)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:0_1(I_give)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:1_1(give_John)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:2_1(John_$900)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:3_1($900_today)",
-                        "WordConjunctionOneTwoThreeGramWindowTwo:4_1(today)"};
+                {"WordConjunctionOneTwoThreeGramWindowTwo:-2_1(construction)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:-1_1(of)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:0_1(the)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:1_1(John)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:2_1(Smith)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:-2_2(construction_of)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:-1_2(of_the)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:0_2(the_John)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:1_2(John_Smith)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:2_2(Smith)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:-2_3(construction_of_the)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:-1_3(of_the_John)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:0_3(the_John_Smith)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:1_3(John_Smith)",
+                        "WordConjunctionOneTwoThreeGramWindowTwo:2_3(Smith)"};
 
-        if (feats == null) {
-            log.debug("Feats are returning NULL.");
-        }
+        if (feats == null) fail("Feats are returning NULL.");
 
-        log.debug("Printing Set of Features");
         for (Feature f : feats) {
-            log.debug(f.getName());
-            assert (ArrayUtils.contains(expected_outputs, f.getName()));
+            assertTrue(ArrayUtils.contains(expected_outputs, f.getName()));
         }
-
-        log.debug("GOT FEATURES YES!");
-
-        // System.exit(0);
     }
-
-
 }


### PR DESCRIPTION
- Fixed a logic error that was causing an out of bounds exception when tested with token indices > window size.
- Also fixed the logic of the `WordConjunctionOneTwoThreeGramWindowTwo` extractor since it was only reporting up to 2grams _(this was a problem in the original LBJ code)_.
- Also fixed the logic of the `PosWordConjunctionSizeTwoWindowSizeTwo` since the word/pos conjunctions were wrong (also only returned 1grams instead of 2grams). _(this was a problem in the original LBJ code)_
- Fixed the unit test for both of these and updated them to use JUnit 4 and `DummyTextAnnotationGenerator`

Closes #129

@danyaljj @mssammon please check the code really carefully and make sure you get someone to fix the other feature extractors.