### PR TITLE
ClauseFeatureExtractor now works with full parses

### DIFF
--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/factory/ClauseFeatureExtractor.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/factory/ClauseFeatureExtractor.java
@@ -46,7 +46,10 @@ public class ClauseFeatureExtractor implements FeatureExtractor {
     public Set<Feature> getFeatures(Constituent c) throws EdisonException {
         TextAnnotation ta = c.getTextAnnotation();
         TreeView pseudoParseView;
-        // If the real parse view exists, use that
+        // If the real parse view exists, use that.
+        // Normally, this feature requires the PSEUDO_PARSE to be manually created by the user
+        // as it is cheaper to make than a full parse. However, there are cases
+        // where the user has already created a full parse view (for other features)
         if (ta.hasView(parseViewName.replace("PSEUDO_", "")))
             pseudoParseView = (TreeView) ta.getView(parseViewName.replace("PSEUDO_", ""));
         else pseudoParseView = (TreeView) ta.getView(parseViewName);

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/factory/ClauseFeatureExtractor.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/features/factory/ClauseFeatureExtractor.java
@@ -45,7 +45,11 @@ public class ClauseFeatureExtractor implements FeatureExtractor {
     @Override
     public Set<Feature> getFeatures(Constituent c) throws EdisonException {
         TextAnnotation ta = c.getTextAnnotation();
-        TreeView pseudoParseView = (TreeView) ta.getView(parseViewName);
+        TreeView pseudoParseView;
+        // If the real parse view exists, use that
+        if (ta.hasView(parseViewName.replace("PSEUDO_", "")))
+            pseudoParseView = (TreeView) ta.getView(parseViewName.replace("PSEUDO_", ""));
+        else pseudoParseView = (TreeView) ta.getView(parseViewName);
         List<Relation> incomingRelations = c.getIncomingRelations();
         Set<Feature> features = new LinkedHashSet<>();
 

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/factory/TestClauseFeatureExtractor.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/features/factory/TestClauseFeatureExtractor.java
@@ -58,8 +58,6 @@ public class TestClauseFeatureExtractor extends TestCase {
             ta.addView(ClauseViewGenerator.CHARNIAK);
             ta.addView(PseudoParse.CHARNIAK);
 
-            System.out.println(ta.getView(ViewNames.PSEUDO_PARSE_CHARNIAK));
-
             PredicateArgumentView pav = (PredicateArgumentView) ta.getView(ViewNames.SRL_VERB);
 
             for (Constituent predicate : pav.getPredicates()) {


### PR DESCRIPTION
Fixes an issue where the user would not create a PSEUDO_PARSE `View` before extracting features (while the full parse existed).