### PR TITLE
Lazyannotator

### DIFF
--- a/chunker/pom.xml
+++ b/chunker/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
 
         <dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-pos</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>

--- a/chunker/pom.xml
+++ b/chunker/pom.xml
@@ -1,8 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-pos</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>

--- a/chunker/pom.xml
+++ b/chunker/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-pos</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>

--- a/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerAnnotator.java
+++ b/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerAnnotator.java
@@ -64,7 +64,6 @@ public class ChunkerAnnotator extends Annotator {
     @Override
     public void initialize(ResourceManager rm)
     {
-        logger.info( "Initializing " + NAME );
         tagger = new Chunker();
     }
 

--- a/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerAnnotator.java
+++ b/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerAnnotator.java
@@ -21,6 +21,7 @@ import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.chunker.main.lbjava.Chunker;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.pos.LBJavaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,11 +62,10 @@ public class ChunkerAnnotator extends Annotator {
     }
 
     @Override
-    public void initialize()
+    public void initialize(ResourceManager rm)
     {
         logger.info( "Initializing " + NAME );
         tagger = new Chunker();
-        super.setIsInitialized();
     }
 
 

--- a/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerAnnotator.java
+++ b/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerAnnotator.java
@@ -36,15 +36,38 @@ import edu.illinois.cs.cogcomp.lbjava.nlp.seg.Token;
 public class ChunkerAnnotator extends Annotator {
     private static final String NAME = ChunkerAnnotator.class.getCanonicalName();
     private final Logger logger = LoggerFactory.getLogger(ChunkerAnnotator.class);
-    private Chunker tagger = new Chunker();
+    private Chunker tagger;
     private String posfield = ViewNames.POS;
     private String tokensfield = ViewNames.TOKENS;
     private String sentencesfield = ViewNames.SENTENCE;
 
 
-    public ChunkerAnnotator() {
-        super(ViewNames.SHALLOW_PARSE, new String[] {ViewNames.POS});
+    /**
+     * default: don't use lazy initialization
+     */
+    public ChunkerAnnotator()
+    {
+        this( false );
     }
+
+    /**
+     * Constructor parameter allows user to specify whether or not to lazily initialize.
+     *
+     * @param lazilyInitialize If set to 'true', models will not be loaded until first call requiring Chunker annotation.
+     */
+    public ChunkerAnnotator(boolean lazilyInitialize ) {
+        super(ViewNames.SHALLOW_PARSE, new String[] {ViewNames.POS}, lazilyInitialize );
+
+    }
+
+    @Override
+    public void initialize()
+    {
+        logger.info( "Initializing " + NAME );
+        tagger = new Chunker();
+        super.setIsInitialized();
+    }
+
 
     @Override
     public void addView(TextAnnotation record) throws AnnotatorException {

--- a/core-utilities/pom.xml
+++ b/core-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core-utilities/pom.xml
+++ b/core-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core-utilities/pom.xml
+++ b/core-utilities/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/Annotator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/Annotator.java
@@ -85,9 +85,8 @@ public abstract class Annotator {
     public Annotator(String viewName, String[] requiredViews, boolean isLazilyInitialized, ResourceManager nonDefaultRm ) {
         this.viewName = viewName;
         this.requiredViews = requiredViews;
-        this.isInitialized = !isLazilyInitialized;
         this.nonDefaultRm = nonDefaultRm;
-
+        isInitialized = false;
         if ( !isLazilyInitialized )
             doInitialize();
     }
@@ -95,7 +94,9 @@ public abstract class Annotator {
 
     /**
      * Derived classes use this to load memory- or time-consuming resources.
-     *
+     * <b>Don't try to log from this method unless your Logger is static.</b> Generated code puts non-static
+     *    Logger initialization in the constructor, so if lazyInitialize is 'false' you'll get a null pointer
+     *    exception trying to write to Logger in initialize().
      * @param rm configuration parameters
      */
     public abstract void initialize( ResourceManager rm );

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/Annotator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/Annotator.java
@@ -12,6 +12,7 @@ package edu.illinois.cs.cogcomp.annotation;
 
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 
 import java.util.Properties;
@@ -46,9 +47,28 @@ public abstract class Annotator {
         this(viewName, requiredViews, false);
     }
 
+    /**
+     * explicitly declare whether lazy initialization should be used
+     * @param viewName
+     * @param requiredViews
+     * @param isLazilyInitialized
+     */
     public Annotator(String viewName, String[] requiredViews, boolean isLazilyInitialized ) {
         this(viewName, requiredViews, isLazilyInitialized, new ResourceManager(new Properties()));
     }
+
+
+    /**
+     * If lazy initialization is desired, set the property {@link Configurator#IS_LAZILY_INITIALIZED} in
+     *   the ResourceManager argument
+     * @param viewName
+     * @param requiredViews
+     * @param rm
+     */
+    public Annotator(String viewName, String[] requiredViews, ResourceManager rm  ) {
+        this(viewName, requiredViews, rm.getBoolean(Configurator.IS_LAZILY_INITIALIZED.key), rm);
+    }
+
 
     /**
      * some annotators have complex initialization, so will have to pass a ResourceManager to be on hand for their
@@ -96,7 +116,7 @@ public abstract class Annotator {
      *
      * @param ta the TextAnnotation to modify.
      */
-    public abstract void addView(TextAnnotation ta) throws AnnotatorException;
+    protected abstract void addView(TextAnnotation ta) throws AnnotatorException;
 
 
     /**

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/AnnotatorConfigurator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/AnnotatorConfigurator.java
@@ -8,22 +8,17 @@
  * University of Illinois at Urbana-Champaign
  * http://cogcomp.cs.illinois.edu/
  */
-package edu.illinois.cs.cogcomp.edison.config;
+package edu.illinois.cs.cogcomp.annotation;
 
-import edu.illinois.cs.cogcomp.annotation.AnnotatorConfigurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.Property;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 
 /**
- *
- * Created by mssammon on 8/10/16.
+ * Annotator configuration options.
  */
-public class SimpleGazetteerAnnotatorConfigurator extends AnnotatorConfigurator {
-
-
-    public static final Property PATH_TO_DICTIONARIES = new Property( "pathToDictionaries", "somepath" );
-    public static final Property PHRASE_LENGTH = new Property("phraseLength", "4" );
+public class AnnotatorConfigurator extends Configurator {
+    public static Property IS_LAZILY_INITIALIZED = new Property( "isLazilyInitialized", FALSE );
 
     /**
      * get a ResourceManager object with the default key/value pairs for this configurator
@@ -32,8 +27,7 @@ public class SimpleGazetteerAnnotatorConfigurator extends AnnotatorConfigurator 
      */
     @Override
     public ResourceManager getDefaultConfig() {
-        Property[] props = new Property[]{ PATH_TO_DICTIONARIES, PHRASE_LENGTH,
-                new Property(IS_LAZILY_INITIALIZED.key, TRUE) };
-        return new ResourceManager(generateProperties(props));
+        Property[] props = new Property[] { IS_LAZILY_INITIALIZED };
+        return new ResourceManager(generateProperties( props ));
     }
 }

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/DummyTextAnnotationGenerator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/DummyTextAnnotationGenerator.java
@@ -37,14 +37,7 @@ public class DummyTextAnnotationGenerator {
     static String annotatedString3 = "The paving commenced Monday and will finish in June .";
 
     static List<String[]> annotatedTokenizedStringArray;
-    static{
-        annotatedTokenizedStringArray = new ArrayList<>();
-        annotatedTokenizedStringArray.add(annotatedString1.split(" "));
-        annotatedTokenizedStringArray.add(annotatedString2.split(" "));
-        annotatedTokenizedStringArray.add(annotatedString3.split(" "));
-    };
-
-    static String[] pos = {"DT", "NN", "IN", "DT", "NNP", "NNP", "NN", "VBD", "IN", "NN", ".",
+        static String[] pos = {"DT", "NN", "IN", "DT", "NNP", "NNP", "NN", "VBD", "IN", "NN", ".",
                             "DT", "NN", "NN", "VBD", "VBN", "IN", "CD", ".",
                             "DT", "VBG", "VBD", "NNP", "CC", "MD", "VB", "IN", "NNP", "." };
     static String[] pos_noisy = {"DT", "NNA", "DT", "DT", "NNP", "NN", "NN", "VB", "IN", "NN", ".",
@@ -52,21 +45,19 @@ public class DummyTextAnnotationGenerator {
                                 "DT", "VBG", "VBD", "NNP", "CC", "MD", "VB", "IN", "NN", "." };
     static String[] lemmas =
             {"the", "construction", "of", "the", "John", "Smith", "library", "finish", "on", "time", ".",
-                    "The", "$10M", "building", "be", "design", "in", "2016", "." +
+                    "The", "$10M", "building", "be", "design", "in", "2016", ".",
                             "The", "paving", "commence", "Monday", "and", "will", "finish", "in", "June", "."
             };
     static String[] lemmas_noisy =
             {"the", "construct", "of", "the", "John", "Smith", "library", "fin", "on", "time", ".",
-            "The", "$10M", "build", "be", "design", "in", "2016", "." +
+            "The", "$10M", "build", "be", "design", "in", "2016", ".",
             "The", "pave", "commence", "Monday", "and", "will", "finish", "in", "June", "." };
-
     static String tree =
             "(S1 (S (NP (NP (DT The) (NN construction)) (PP (IN of) (NP (DT the) (NNP John) (NNP Smith) (NN library)))) "
                     + "(VP (VBD finished) (PP (IN on) (NP (NN time)))) (. .)))";
     static String tree2 = "(S1 (S (NP (DT The) (JJ $10M) (NN building)) (VP (AUX was) (VP (VBN designed) (PP (IN in) " +
             "(NP (CD 2016)))))(. .)))";
     static String tree3 = "(S1 (S (NP (DT The)(NN paving))(VP (VP (VBD commenced)(NP (NNP Monday)))(CC and)(VP (MD will)(VP (VB finish)(PP (IN in)(NP (NNP June))))))(. .)))";
-
     static String tree_noisy =
             "(S1 (S (NP (NP (DT The) (NNA construction) (IN of)) (PP (NP (DT the) (NNP John) (NN Smith) (NN library)))) "
                     + "(VP (VB finished) (PP (IN on) (NP (NN time)))) (. .)))";
@@ -74,9 +65,34 @@ public class DummyTextAnnotationGenerator {
             "(NP (CD 2016)))))(. .)))";
     static String tree_noisy3 = "(S1 (S (NP (DT The) (JJ paving)) (VP (VP (VBD commenced) (NP (NNP Monday))) (CC and)" +
             "(VP (MD will) (VP (VB finish) (PP (IN in) (NP (NNP June)))))) (. .)))";
-
     static Map<IntPair, String> chunks = new HashMap<>();
     static Map<IntPair, String> ner = new HashMap<>();
+    static Map<IntPair, String> chunks_noisy = new HashMap<>();
+    static Map<IntPair, String> ner_noisy = new HashMap<>();
+    static IntPair verbSRLPredicate = new IntPair(7, 8);
+    static String verbSRLPredicateSense = "01";
+    static String verbSRLPredicateSense_noisy = "02";
+    static Map<IntPair, String> verbSRLArgs = new HashMap<>();
+    static Map<IntPair, String> verbSRLArgs2 = new HashMap<>();
+    static Map<IntPair, String> verbSRLArgs3 = new HashMap<>();
+    static Map<IntPair, String> verbSRLArgs4 = new HashMap<>();
+    static IntPair verbSRLPredicate2 = new IntPair(15, 16);
+    static IntPair verbSRLPredicate3 = new IntPair(21, 22);
+    static IntPair verbSRLPredicate4 = new IntPair(25, 26);
+    static Map<IntPair, String> verbSRLArgs_noisy = new HashMap<>();
+    static Map<IntPair, String> verbSRLArgs_noisy2 = new HashMap<>();
+    static Map<IntPair, String> verbSRLArgs_noisy3 = new HashMap<>();
+    static Map<IntPair, String> verbSRLArgs_noisy4 = new HashMap<>();
+    private static String[] allPossibleViews = new String[] {ViewNames.POS, ViewNames.LEMMA,
+            ViewNames.SHALLOW_PARSE, ViewNames.PARSE_GOLD, ViewNames.SRL_VERB, ViewNames.NER_CONLL,
+            ViewNames.PSEUDO_PARSE_STANFORD };
+
+static{
+        annotatedTokenizedStringArray = new ArrayList<>();
+        annotatedTokenizedStringArray.add(annotatedString1.split(" "));
+        annotatedTokenizedStringArray.add(annotatedString2.split(" "));
+        annotatedTokenizedStringArray.add(annotatedString3.split(" "));
+    }
 
     static {
         chunks.put(new IntPair(0, 2), "NP");
@@ -101,9 +117,6 @@ public class DummyTextAnnotationGenerator {
         ner.put(new IntPair(4, 6), "PER" );
     }
 
-    static Map<IntPair, String> chunks_noisy = new HashMap<>();
-    static Map<IntPair, String> ner_noisy = new HashMap<>();
-
     static {
         chunks_noisy.put(new IntPair(0, 2), "NP");
         chunks_noisy.put(new IntPair(2, 3), "PP");
@@ -127,19 +140,6 @@ public class DummyTextAnnotationGenerator {
         ner_noisy.put( new IntPair(27, 28), "PER" );
     }
 
-    static IntPair verbSRLPredicate = new IntPair(7, 8);
-    static String verbSRLPredicateSense = "01";
-    static String verbSRLPredicateSense_noisy = "02";
-    static Map<IntPair, String> verbSRLArgs = new HashMap<>();
-    static Map<IntPair, String> verbSRLArgs2 = new HashMap<>();
-    static Map<IntPair, String> verbSRLArgs3 = new HashMap<>();
-    static Map<IntPair, String> verbSRLArgs4 = new HashMap<>();
-
-
-    static IntPair verbSRLPredicate2 = new IntPair(15, 16);
-    static IntPair verbSRLPredicate3 = new IntPair(21, 22);
-    static IntPair verbSRLPredicate4 = new IntPair(25, 26);
-
     static {
         verbSRLArgs.put(new IntPair(0, 7), "A0");
         verbSRLArgs.put(new IntPair(8, 10), "AM-TMP");
@@ -155,11 +155,6 @@ public class DummyTextAnnotationGenerator {
         verbSRLArgs4.put(new IntPair(26, 28), "AM-TMP");
 
     }
-
-    static Map<IntPair, String> verbSRLArgs_noisy = new HashMap<>();
-    static Map<IntPair, String> verbSRLArgs_noisy2 = new HashMap<>();
-    static Map<IntPair, String> verbSRLArgs_noisy3 = new HashMap<>();
-    static Map<IntPair, String> verbSRLArgs_noisy4 = new HashMap<>();
 
     static {
         verbSRLArgs_noisy.put(new IntPair(0, 7), "A0");
@@ -192,10 +187,6 @@ public class DummyTextAnnotationGenerator {
         }
         return BasicTextAnnotationBuilder.createTextAnnotationFromTokens(docs);
     }
-
-    private static String[] allPossibleViews = new String[] {ViewNames.POS, ViewNames.LEMMA,
-            ViewNames.SHALLOW_PARSE, ViewNames.PARSE_GOLD, ViewNames.SRL_VERB, ViewNames.NER_CONLL,
-            ViewNames.PSEUDO_PARSE_STANFORD };
 
     public static TextAnnotation generateAnnotatedTextAnnotation(boolean withNoisyLabels) {
         return generateAnnotatedTextAnnotation(allPossibleViews, withNoisyLabels);

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/configuration/Configurator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/configuration/Configurator.java
@@ -40,13 +40,13 @@ public abstract class Configurator {
     public static final String FALSE = Boolean.FALSE.toString();
 
     /**
-     * combine two sets of properties to make a third Properties object; throw exception if two
-     * properties clash (have same name)
+     * combine two sets of properties to make a third Properties object; if both sets contain a value
+     *    for the same key, the value from the second ResourceManager is selected.
      *
      * @param first ResourceManager with first set of properties
      * @param second ResourceManager with second set of properties
-     * @return a brand new ResourceManager with the union of the properties
-     * @throws IllegalArgumentException if the same key appears in both objects
+     * @return a brand new ResourceManager with the union of the properties, favoring the second
+     *         if the same property is set in both
      */
     public static ResourceManager mergeProperties(ResourceManager first, ResourceManager second) {
         Properties firstProps = first.getProperties();
@@ -57,14 +57,9 @@ public abstract class Configurator {
         for (String key : firstProps.stringPropertyNames())
             newProps.put(key, firstProps.getProperty(key));
 
-        for (String key : secondProps.stringPropertyNames()) {
-            // if ( newProps.containsKey( key ) )
-            // throw new IllegalArgumentException( "ERROR: key '" + key +
-            // "' was already set in first ResourceManager." );
-
+        for (String key : secondProps.stringPropertyNames())
             newProps.put(key, secondProps.getProperty(key));
-        }
-
+        
         return new ResourceManager(newProps);
     }
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/configuration/Configurator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/configuration/Configurator.java
@@ -38,71 +38,11 @@ public abstract class Configurator {
 
     public static final String TRUE = Boolean.TRUE.toString();
     public static final String FALSE = Boolean.FALSE.toString();
-    public static Property IS_LAZILY_INITIALIZED = new Property( "isLazilyInitialized", FALSE );
-
-    /**
-     * get a ResourceManager object with the default key/value pairs for this configurator
-     * 
-     * @return a non-null ResourceManager with appropriate values set.
-     */
-    abstract public ResourceManager getDefaultConfig();
-
-    /**
-     * Creates the {@link java.util.Properties} that is passed on to {@link ResourceManager} from a
-     * list of default {@link Property} entries.
-     * 
-     * @param properties The list default {@link Property} entries
-     * @return The {@link java.util.Properties} containing the defined properties
-     */
-    protected Properties generateProperties(Property[] properties) {
-        Properties props = new Properties();
-        for (Property property : properties)
-            props.setProperty(property.key, property.value);
-        return props;
-    }
-
-    /**
-     * get a Properties object with default values except for those provided in the
-     * 'nonDefaultValues' argument
-     * 
-     * @param nonDefaultValues specify ONLY those values you wish to override
-     * @return a {@link ResourceManager} containing the defined properties
-     */
-    public ResourceManager getConfig(Map<String, String> nonDefaultValues) {
-        ResourceManager props = getDefaultConfig();
-        Properties nonDefProps = new Properties();
-        nonDefProps.putAll(nonDefaultValues);
-
-        return mergeProperties(props, new ResourceManager(nonDefProps));
-    }
-
-
-    /**
-     * get a Properties object with default values except for those provided in the
-     * 'nonDefaultValues' argument
-     * 
-     * @param nonDefaultRm specify ONLY those values you wish to override
-     * @return a {@link ResourceManager} containing the defined properties
-     */
-    public ResourceManager getConfig(ResourceManager nonDefaultRm) {
-        ResourceManager props = getDefaultConfig();
-        Properties nonDefProps = new Properties();
-
-        Enumeration<String> keys =
-                (Enumeration<String>) nonDefaultRm.getProperties().propertyNames();
-
-        while (keys.hasMoreElements()) {
-            String key = keys.nextElement();
-            nonDefProps.put(key, nonDefaultRm.getString(key));
-        }
-        return mergeProperties(props, new ResourceManager(nonDefProps));
-    }
-
 
     /**
      * combine two sets of properties to make a third Properties object; throw exception if two
      * properties clash (have same name)
-     * 
+     *
      * @param first ResourceManager with first set of properties
      * @param second ResourceManager with second set of properties
      * @return a brand new ResourceManager with the union of the properties
@@ -130,7 +70,7 @@ public abstract class Configurator {
 
     /**
      * merge a list of ResourceManager objects
-     * 
+     *
      * @param rmList list of ResourceManager objects
      * @return single ResourceManager containing union of properties of objects in argument
      */
@@ -145,6 +85,63 @@ public abstract class Configurator {
             finalRm = Configurator.mergeProperties(finalRm, rmList.get(i));
 
         return finalRm;
+    }
+
+    /**
+     * get a ResourceManager object with the default key/value pairs for this configurator
+     *
+     * @return a non-null ResourceManager with appropriate values set.
+     */
+    abstract public ResourceManager getDefaultConfig();
+
+    /**
+     * Creates the {@link java.util.Properties} that is passed on to {@link ResourceManager} from a
+     * list of default {@link Property} entries.
+     *
+     * @param properties The list default {@link Property} entries
+     * @return The {@link java.util.Properties} containing the defined properties
+     */
+    protected Properties generateProperties(Property[] properties) {
+        Properties props = new Properties();
+        for (Property property : properties)
+            props.setProperty(property.key, property.value);
+        return props;
+    }
+
+    /**
+     * get a Properties object with default values except for those provided in the
+     * 'nonDefaultValues' argument
+     *
+     * @param nonDefaultValues specify ONLY those values you wish to override
+     * @return a {@link ResourceManager} containing the defined properties
+     */
+    public ResourceManager getConfig(Map<String, String> nonDefaultValues) {
+        ResourceManager props = getDefaultConfig();
+        Properties nonDefProps = new Properties();
+        nonDefProps.putAll(nonDefaultValues);
+
+        return mergeProperties(props, new ResourceManager(nonDefProps));
+    }
+
+    /**
+     * get a Properties object with default values except for those provided in the
+     * 'nonDefaultValues' argument
+     *
+     * @param nonDefaultRm specify ONLY those values you wish to override
+     * @return a {@link ResourceManager} containing the defined properties
+     */
+    public ResourceManager getConfig(ResourceManager nonDefaultRm) {
+        ResourceManager props = getDefaultConfig();
+        Properties nonDefProps = new Properties();
+
+        Enumeration<String> keys =
+                (Enumeration<String>) nonDefaultRm.getProperties().propertyNames();
+
+        while (keys.hasMoreElements()) {
+            String key = keys.nextElement();
+            nonDefProps.put(key, nonDefaultRm.getString(key));
+        }
+        return mergeProperties(props, new ResourceManager(nonDefProps));
     }
 
 }

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/configuration/Configurator.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/configuration/Configurator.java
@@ -38,6 +38,7 @@ public abstract class Configurator {
 
     public static final String TRUE = Boolean.TRUE.toString();
     public static final String FALSE = Boolean.FALSE.toString();
+    public static Property IS_LAZILY_INITIALIZED = new Property( "isLazilyInitialized", FALSE );
 
     /**
      * get a ResourceManager object with the default key/value pairs for this configurator

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/nlp/utilities/POSFromParse.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/nlp/utilities/POSFromParse.java
@@ -15,6 +15,7 @@ import edu.illinois.cs.cogcomp.annotation.BasicAnnotatorService;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
 import edu.illinois.cs.cogcomp.core.datastructures.trees.Tree;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 
 /**
  * Generates a part-of-speech view using the pre-terminals from a parse tree.
@@ -33,6 +34,16 @@ public class POSFromParse extends Annotator {
     public POSFromParse(String parseViewName) {
         super(ViewNames.POS, new String[] {parseViewName});
         this.parseViewName = parseViewName;
+    }
+
+    /**
+     * Derived classes use this to load memory- or time-consuming resources.
+     *
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ; // noop
     }
 
     @Override

--- a/corpusreaders/pom.xml
+++ b/corpusreaders/pom.xml
@@ -1,10 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/corpusreaders/pom.xml
+++ b/corpusreaders/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/corpusreaders/pom.xml
+++ b/corpusreaders/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/curator/pom.xml
+++ b/curator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <!-- Curator-related dependencies -->

--- a/curator/pom.xml
+++ b/curator/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <!-- Curator-related dependencies -->

--- a/curator/pom.xml
+++ b/curator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
 
         <!-- Curator-related dependencies -->

--- a/curator/src/main/java/edu/illinois/cs/cogcomp/curator/CuratorAnnotator.java
+++ b/curator/src/main/java/edu/illinois/cs/cogcomp/curator/CuratorAnnotator.java
@@ -47,9 +47,7 @@ public class CuratorAnnotator extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) throws AnnotatorException {

--- a/curator/src/main/java/edu/illinois/cs/cogcomp/curator/CuratorAnnotator.java
+++ b/curator/src/main/java/edu/illinois/cs/cogcomp/curator/CuratorAnnotator.java
@@ -14,6 +14,7 @@ import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
 import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.thrift.base.AnnotationFailedException;
 import edu.illinois.cs.cogcomp.thrift.base.ServiceUnavailableException;
 import org.apache.thrift.TException;
@@ -39,6 +40,16 @@ public class CuratorAnnotator extends Annotator {
         this.curatorClient = curatorClient;
     }
 
+
+    /**
+     * noop
+     *
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
+    }
 
     @Override
     public void addView(TextAnnotation ta) throws AnnotatorException {

--- a/edison/pom.xml
+++ b/edison/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -26,13 +26,13 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-corpusreaders</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <!-- Used only in utilities.CreateTestTAResource -->
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-curator</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
             <scope>test</scope>
         </dependency>
         <!-- Used only in features.FeatureUtilities to convert to LBJava-based feature vectors -->

--- a/edison/pom.xml
+++ b/edison/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -26,13 +26,13 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-corpusreaders</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <!-- Used only in utilities.CreateTestTAResource -->
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-curator</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <!-- Used only in features.FeatureUtilities to convert to LBJava-based feature vectors -->

--- a/edison/pom.xml
+++ b/edison/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -26,13 +26,13 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-corpusreaders</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <!-- Used only in utilities.CreateTestTAResource -->
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-curator</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <!-- Used only in features.FeatureUtilities to convert to LBJava-based feature vectors -->

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/BrownClusterViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/BrownClusterViewGenerator.java
@@ -151,9 +151,7 @@ public class BrownClusterViewGenerator extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/BrownClusterViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/BrownClusterViewGenerator.java
@@ -18,6 +18,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.core.io.IOUtils;
 import edu.illinois.cs.cogcomp.core.utilities.StringUtils;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -143,6 +144,16 @@ public class BrownClusterViewGenerator extends Annotator {
 
     }
 
+
+    /**
+     * noop -- uses its own lazy initialization.
+     *
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
+    }
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/ClauseViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/ClauseViewGenerator.java
@@ -14,6 +14,7 @@ import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.nlp.utilities.ParseTreeProperties;
 import edu.illinois.cs.cogcomp.nlp.utilities.ParseUtils;
 
@@ -46,6 +47,15 @@ public class ClauseViewGenerator extends Annotator {
         this.clauseViewName = clauseViewName;
     }
 
+
+    /**
+     * noop.
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
+    }
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/ClauseViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/ClauseViewGenerator.java
@@ -53,9 +53,7 @@ public class ClauseViewGenerator extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/GazetteerViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/GazetteerViewGenerator.java
@@ -391,9 +391,7 @@ public class GazetteerViewGenerator extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/GazetteerViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/GazetteerViewGenerator.java
@@ -19,6 +19,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
 import edu.illinois.cs.cogcomp.core.io.IOUtils;
 import edu.illinois.cs.cogcomp.core.transformers.Predicate;
 import edu.illinois.cs.cogcomp.core.utilities.StringUtils;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.edison.features.helpers.WordHelpers;
 import edu.illinois.cs.cogcomp.edison.utilities.EdisonException;
 import edu.illinois.cs.cogcomp.annotation.BasicTextAnnotationBuilder;
@@ -381,6 +382,16 @@ public class GazetteerViewGenerator extends Annotator {
      */
     public List<String> getGazetteerNames() {
         return Collections.unmodifiableList(names);
+
+    }
+
+    /**
+     * noop. Uses own lazy initialization.
+     *
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
 
     }
 

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/HeadFinderDependencyViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/HeadFinderDependencyViewGenerator.java
@@ -104,9 +104,7 @@ public class HeadFinderDependencyViewGenerator extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/HeadFinderDependencyViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/HeadFinderDependencyViewGenerator.java
@@ -15,6 +15,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
 import edu.illinois.cs.cogcomp.core.datastructures.trees.Tree;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.nlp.utilities.CollinsHeadDependencyParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,20 +94,27 @@ public class HeadFinderDependencyViewGenerator extends Annotator {
         return depTreeView;
     }
 
+    private static String buildViewName(String parseViewName) {
+        return ViewNames.DEPENDENCY_HEADFINDER + ":" + parseViewName;
+    }
+
+    /**
+     * noop.
+     *
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
+    }
+
     @Override
     public void addView(TextAnnotation ta) {
         ta.addView(getViewName(), getDependencyTree(ta, parseViewName, getViewName()));
     }
 
-
     @Override
     public String getViewName() {
         return buildViewName(parseViewName);
-    }
-
-
-
-    private static String buildViewName(String parseViewName) {
-        return ViewNames.DEPENDENCY_HEADFINDER + ":" + parseViewName;
     }
 }

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/POSFromParse.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/POSFromParse.java
@@ -14,6 +14,7 @@ import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
 import edu.illinois.cs.cogcomp.core.datastructures.trees.Tree;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.nlp.utilities.ParseUtils;
 
 /**
@@ -33,6 +34,15 @@ public class POSFromParse extends Annotator {
     public POSFromParse(String parseViewName) {
         super(ViewNames.POS, new String[] {parseViewName});
         this.parseViewName = parseViewName;
+    }
+
+    /**
+     * noop.
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
     }
 
     @Override

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/POSFromParse.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/POSFromParse.java
@@ -41,9 +41,7 @@ public class POSFromParse extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PorterStemmer.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PorterStemmer.java
@@ -15,6 +15,7 @@ import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import org.tartarus.snowball.SnowballStemmer;
 import org.tartarus.snowball.ext.englishStemmer;
 
@@ -26,9 +27,12 @@ import org.tartarus.snowball.ext.englishStemmer;
  */
 public class PorterStemmer extends Annotator {
 
+    private final static SnowballStemmer stemmer = new englishStemmer();
     private static PorterStemmer instance = null; // = new PorterStemmer();
 
-    private final static SnowballStemmer stemmer = new englishStemmer();
+    private PorterStemmer(String viewName, String[] prerequisiteViews) {
+        super(viewName, prerequisiteViews);
+    }
 
     public static PorterStemmer getInstance() {
         if (null == instance)
@@ -36,8 +40,13 @@ public class PorterStemmer extends Annotator {
         return instance;
     }
 
-    private PorterStemmer(String viewName, String[] prerequisiteViews) {
-        super(viewName, prerequisiteViews);
+    /**
+     * noop.
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+
     }
 
     @Override

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PorterStemmer.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PorterStemmer.java
@@ -45,9 +45,7 @@ public class PorterStemmer extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation input) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PseudoParse.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PseudoParse.java
@@ -55,9 +55,7 @@ public class PseudoParse extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PseudoParse.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/PseudoParse.java
@@ -16,6 +16,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
 import edu.illinois.cs.cogcomp.core.datastructures.trees.Tree;
 import edu.illinois.cs.cogcomp.core.datastructures.trees.TreeParserFactory;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.nlp.utilities.SentenceUtils;
 
 import java.util.ArrayList;
@@ -47,6 +48,15 @@ public class PseudoParse extends Annotator {
         this.clauseViewName = clauseViewName;
         this.pseudoParseViewName = pseudoParseViewName;
 
+    }
+
+    /**
+     * noop.
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
     }
 
     @Override

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotator.java
@@ -45,8 +45,8 @@ public class SimpleGazetteerAnnotator extends Annotator {
     ArrayList<GazetteerTree> dictionariesIgnoreCase = new ArrayList<>();
 
     /**
-     * Making this private ensures singleton.
-     * @param phrase_length the max length of the phrases we will consider.
+     * Loads phrases of length 4 or less from specified gazetteers.
+     * @param pathToDictionaries directory containing the gazetteer files
      * @throws IOException
      * @throws URISyntaxException 
      */
@@ -56,8 +56,8 @@ public class SimpleGazetteerAnnotator extends Annotator {
     }
 
     /**
-     * Making this private ensures singleton.
      * @param phrase_length the max length of the phrases we will consider.
+     * @param pathToDictionaries directory containing the gazetteer files
      * @throws IOException
      * @throws URISyntaxException 
      */
@@ -69,7 +69,7 @@ public class SimpleGazetteerAnnotator extends Annotator {
     /**
      * Lists the contents of a directory that exists either in the local path or in the classpath
      * 
-     * @param directory The name of the directory containing the gazetteers
+     * @param resourceDir The name of the directory containing the gazetteers
      * @return An array of URL objects to be read
      * @throws IOException
      * @throws  

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotator.java
@@ -41,14 +41,12 @@ import edu.illinois.cs.cogcomp.edison.features.helpers.GazetteerTree;
  */
 public class SimpleGazetteerAnnotator extends Annotator {
 
-    private int phraseLength;
-    private String pathToDictionaries;
-
     /** this hash tree contains the terms as exactly as they are. */
     ArrayList<GazetteerTree> dictionaries;
-
     /** this hash tree contains the terms in lowercase. */
     ArrayList<GazetteerTree> dictionariesIgnoreCase;
+    private int phraseLength;
+    private String pathToDictionaries;
 
 
 
@@ -102,9 +100,9 @@ public class SimpleGazetteerAnnotator extends Annotator {
      * @throws URISyntaxException 
      */
     @Override
-    public void initialize() {
-        this.phraseLength = nonDefaultRm.getInt( SimpleGazetteerAnnotatorConfigurator.PHRASE_LENGTH );
-        this.pathToDictionaries = nonDefaultRm.getString( SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES );
+    public void initialize( ResourceManager rm ) {
+        this.phraseLength = rm.getInt( SimpleGazetteerAnnotatorConfigurator.PHRASE_LENGTH );
+        this.pathToDictionaries = rm.getString( SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES );
 //        int phrase_length, String pathToDictionaries) throws IOException {
         ArrayList<URL> filenames = new ArrayList<>();
 

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotator.java
@@ -27,6 +27,8 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.SpanLabelView;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.core.io.IOUtils;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
+import edu.illinois.cs.cogcomp.edison.config.SimpleGazetteerAnnotatorConfigurator;
 import edu.illinois.cs.cogcomp.edison.features.helpers.GazetteerTree;
 
 /**
@@ -39,49 +41,37 @@ import edu.illinois.cs.cogcomp.edison.features.helpers.GazetteerTree;
  */
 public class SimpleGazetteerAnnotator extends Annotator {
 
-    private final int phraseLength;
-    private final String pathToDictionaries;
+    private int phraseLength;
+    private String pathToDictionaries;
 
     /** this hash tree contains the terms as exactly as they are. */
-    ArrayList<GazetteerTree> dictionaries = new ArrayList<>();
+    ArrayList<GazetteerTree> dictionaries;
 
     /** this hash tree contains the terms in lowercase. */
-    ArrayList<GazetteerTree> dictionariesIgnoreCase = new ArrayList<>();
+    ArrayList<GazetteerTree> dictionariesIgnoreCase;
 
 
-    /**
-     * Loads phrases of length 4 or less from specified gazetteers. Uses lazy initialization: resource files won't be
-     *     loaded until this annotator is called on to populate a View.
-     *
-     * @param pathToDictionaries directory containing the gazetteer files
-     * @throws IOException
-     * @throws URISyntaxException
-     */
-    public SimpleGazetteerAnnotator(String pathToDictionaries) throws IOException, URISyntaxException {
-        this(4, pathToDictionaries, true );
-    }
 
     /**
-     * Loads phrases of length 4 or less from specified gazetteers.
-     * @param pathToDictionaries directory containing the gazetteer files
-     * @param isLazilyInitialized if 'true', won't load resources until this annotator is required to populate a View
+     * Loads phrases of length 4 or less from gazetteers specified in default parameter
+     *   {@link SimpleGazetteerAnnotatorConfigurator#PATH_TO_DICTIONARIES}
      * @throws IOException
      * @throws URISyntaxException 
      */
-    public SimpleGazetteerAnnotator(String pathToDictionaries, boolean isLazilyInitialized) throws IOException, URISyntaxException {
-        this(4, pathToDictionaries, isLazilyInitialized );
+    public SimpleGazetteerAnnotator() throws IOException, URISyntaxException {
+        this(new SimpleGazetteerAnnotatorConfigurator().getDefaultConfig());
     }
 
     /**
-     * @param phraseLength the max length of the phrases we will consider.
-     * @param pathToDictionaries directory containing the gazetteer files
+     * ResourceManager can override properties in {@link SimpleGazetteerAnnotatorConfigurator}
      * @throws IOException
      * @throws URISyntaxException 
      */
-    public SimpleGazetteerAnnotator(int phraseLength, String pathToDictionaries, boolean isLazilyInitialized) throws IOException, URISyntaxException {
-        super(ViewNames.TREE_GAZETTEER, new String[] {ViewNames.SENTENCE, ViewNames.TOKENS}, isLazilyInitialized);
-        this.phraseLength = phraseLength;
-        this.pathToDictionaries = pathToDictionaries;
+    public SimpleGazetteerAnnotator(ResourceManager nonDefaultRm) throws IOException, URISyntaxException {
+        super(ViewNames.TREE_GAZETTEER,
+                new String[] {ViewNames.SENTENCE, ViewNames.TOKENS},
+                new SimpleGazetteerAnnotatorConfigurator().getConfig( nonDefaultRm ) );
+
     }
 
     /**
@@ -113,6 +103,8 @@ public class SimpleGazetteerAnnotator extends Annotator {
      */
     @Override
     public void initialize() {
+        this.phraseLength = nonDefaultRm.getInt( SimpleGazetteerAnnotatorConfigurator.PHRASE_LENGTH );
+        this.pathToDictionaries = nonDefaultRm.getString( SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES );
 //        int phrase_length, String pathToDictionaries) throws IOException {
         ArrayList<URL> filenames = new ArrayList<>();
 

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetLemmaViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetLemmaViewGenerator.java
@@ -44,9 +44,7 @@ public class WordNetLemmaViewGenerator extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetLemmaViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetLemmaViewGenerator.java
@@ -14,6 +14,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.edison.features.helpers.WordHelpers;
 import edu.illinois.cs.cogcomp.edison.utilities.WordNetHelper;
 import edu.illinois.cs.cogcomp.edison.utilities.WordNetManager;
@@ -36,6 +37,15 @@ public class WordNetLemmaViewGenerator extends Annotator {
     public WordNetLemmaViewGenerator(WordNetManager wn) {
         super(ViewNames.LEMMA, new String[] {ViewNames.POS});
         this.wn = wn;
+    }
+
+    /**
+     * noop.
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
     }
 
     @Override

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetPlusLemmaViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetPlusLemmaViewGenerator.java
@@ -16,6 +16,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.core.io.IOUtils;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.edison.features.helpers.WordHelpers;
 import edu.illinois.cs.cogcomp.edison.utilities.EdisonException;
 import edu.illinois.cs.cogcomp.edison.utilities.WordNetHelper;
@@ -77,6 +78,15 @@ public class WordNetPlusLemmaViewGenerator extends Annotator {
         this.wn = wn;
     }
 
+
+    /**
+     * noop
+     * @param rm configuration parameters
+     */
+    @Override
+    public void initialize(ResourceManager rm) {
+        ;
+    }
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetPlusLemmaViewGenerator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/annotators/WordNetPlusLemmaViewGenerator.java
@@ -84,9 +84,7 @@ public class WordNetPlusLemmaViewGenerator extends Annotator {
      * @param rm configuration parameters
      */
     @Override
-    public void initialize(ResourceManager rm) {
-        ;
-    }
+    public void initialize(ResourceManager rm) {}
 
     @Override
     public void addView(TextAnnotation ta) {

--- a/edison/src/main/java/edu/illinois/cs/cogcomp/edison/config/SimpleGazetteerAnnotatorConfigurator.java
+++ b/edison/src/main/java/edu/illinois/cs/cogcomp/edison/config/SimpleGazetteerAnnotatorConfigurator.java
@@ -1,0 +1,38 @@
+/**
+ * This software is released under the University of Illinois/Research and
+ *  Academic Use License. See the LICENSE file in the root folder for details.
+ * Copyright (c) 2016
+ *
+ * Developed by:
+ * The Cognitive Computation Group
+ * University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.edison.config;
+
+import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.Property;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
+
+/**
+ *
+ * Created by mssammon on 8/10/16.
+ */
+public class SimpleGazetteerAnnotatorConfigurator extends Configurator {
+
+
+    public static final Property PATH_TO_DICTIONARIES = new Property( "pathToDictionaries", "somepath" );
+    public static final Property PHRASE_LENGTH = new Property("phraseLength", "4" );
+
+    /**
+     * get a ResourceManager object with the default key/value pairs for this configurator
+     *
+     * @return a non-null ResourceManager with appropriate values set.
+     */
+    @Override
+    public ResourceManager getDefaultConfig() {
+        Property[] props = new Property[]{ PATH_TO_DICTIONARIES, PHRASE_LENGTH,
+                new Property(IS_LAZILY_INITIALIZED.key, TRUE) };
+        return new ResourceManager(generateProperties(props));
+    }
+}

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/AnnotatorLazyInitTest.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/AnnotatorLazyInitTest.java
@@ -1,14 +1,30 @@
+/**
+ * This software is released under the University of Illinois/Research and
+ *  Academic Use License. See the LICENSE file in the root folder for details.
+ * Copyright (c) 2016
+ *
+ * Developed by:
+ * The Cognitive Computation Group
+ * University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
 package edu.illinois.cs.cogcomp.edison.annotators;
 
 import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
 import edu.illinois.cs.cogcomp.annotation.TextAnnotationBuilder;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
+import edu.illinois.cs.cogcomp.edison.config.SimpleGazetteerAnnotatorConfigurator;
 import edu.illinois.cs.cogcomp.nlp.tokenizer.StatefulTokenizer;
 import edu.illinois.cs.cogcomp.nlp.utility.TokenizerTextAnnotationBuilder;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Properties;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -20,14 +36,26 @@ import static org.junit.Assert.fail;
  */
 public class AnnotatorLazyInitTest
 {
+    private static ResourceManager defaultRm;
     protected final TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
+
+    @BeforeClass
+    public static void setUpOnce()
+    {
+        Properties props = new Properties();
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, Configurator.FALSE);
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES.key, "/testgazetteers/" );
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.PHRASE_LENGTH.key, "6" );
+        defaultRm = new ResourceManager(props);
+    }
+
 
     @Test
     public void testNonLazy()
     {
         SimpleGazetteerAnnotator sga = null;
         try {
-            sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", false);
+            sga = new SimpleGazetteerAnnotator(defaultRm);
         } catch (IOException | URISyntaxException e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -43,8 +71,12 @@ public class AnnotatorLazyInitTest
     public void testLazy()
     {
         SimpleGazetteerAnnotator sga = null;
+        Properties props = new Properties();
+        props.setProperty( SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES.key, "/testgazetteers/" );
+        props.setProperty( SimpleGazetteerAnnotatorConfigurator.PHRASE_LENGTH.key, "6" );
+        props.setProperty( SimpleGazetteerAnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, SimpleGazetteerAnnotatorConfigurator.TRUE );
         try {
-            sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", true);
+            sga = new SimpleGazetteerAnnotator( new ResourceManager(props) );
         } catch (IOException | URISyntaxException e) {
             e.printStackTrace();
             fail(e.getMessage());
@@ -52,21 +84,21 @@ public class AnnotatorLazyInitTest
 
         assertFalse( sga.isInitialized() );
 
-        assertTrue( sga.dictionaries.size() == 0 );
-        assertTrue( sga.dictionariesIgnoreCase.size() == 0 );
+        assertTrue( null == sga.dictionaries ? true : sga.dictionaries.size() > 0 );
+        assertTrue( null == sga.dictionariesIgnoreCase ? true : sga.dictionariesIgnoreCase.size() > 0 );
 
         TextAnnotation ta = tab.createTextAnnotation("The CIA has no London headquarters, though General Electric does." );
 
         try {
-            sga.addView( ta );
+            sga.getView( ta );
         } catch (AnnotatorException e) {
             e.printStackTrace();
             fail( e.getMessage() );
         }
-
+        assertTrue( ta.hasView( sga.getViewName() ) );
         assertTrue( sga.isInitialized() );
-        assertTrue( sga.dictionaries.size() > 0 );
-        assertTrue( sga.dictionariesIgnoreCase.size() > 0 );
+        assertTrue( null == sga.dictionaries ? true : sga.dictionaries.size() > 0 );
+        assertTrue( null == sga.dictionariesIgnoreCase ? true : sga.dictionariesIgnoreCase.size() > 0 );
 
         assertTrue(ta.hasView( sga.getViewName() ));
     }

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/AnnotatorLazyInitTest.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/AnnotatorLazyInitTest.java
@@ -1,0 +1,74 @@
+package edu.illinois.cs.cogcomp.edison.annotators;
+
+import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
+import edu.illinois.cs.cogcomp.annotation.TextAnnotationBuilder;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.nlp.tokenizer.StatefulTokenizer;
+import edu.illinois.cs.cogcomp.nlp.utility.TokenizerTextAnnotationBuilder;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * Test lazy initialization behavior of Annotator.
+ * @author mssammon
+ */
+public class AnnotatorLazyInitTest
+{
+    protected final TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
+
+    @Test
+    public void testNonLazy()
+    {
+        SimpleGazetteerAnnotator sga = null;
+        try {
+            sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", false);
+        } catch (IOException | URISyntaxException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+
+        assertTrue( sga.isInitialized() );
+
+        assertTrue( sga.dictionaries.size() > 0 );
+        assertTrue( sga.dictionariesIgnoreCase.size() > 0 );
+    }
+
+    @Test
+    public void testLazy()
+    {
+        SimpleGazetteerAnnotator sga = null;
+        try {
+            sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", true);
+        } catch (IOException | URISyntaxException e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+
+        assertFalse( sga.isInitialized() );
+
+        assertTrue( sga.dictionaries.size() == 0 );
+        assertTrue( sga.dictionariesIgnoreCase.size() == 0 );
+
+        TextAnnotation ta = tab.createTextAnnotation("The CIA has no London headquarters, though General Electric does." );
+
+        try {
+            sga.addView( ta );
+        } catch (AnnotatorException e) {
+            e.printStackTrace();
+            fail( e.getMessage() );
+        }
+
+        assertTrue( sga.isInitialized() );
+        assertTrue( sga.dictionaries.size() > 0 );
+        assertTrue( sga.dictionariesIgnoreCase.size() > 0 );
+
+        assertTrue(ta.hasView( sga.getViewName() ));
+    }
+
+}

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotatorTest.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotatorTest.java
@@ -41,7 +41,8 @@ import edu.illinois.cs.cogcomp.nlp.utility.TokenizerTextAnnotationBuilder;
  * @author redman
  */
 public class SimpleGazetteerAnnotatorTest {
-    /** this helper can create text annotations from text. */
+	private static final boolean IS_LAZILY_INITIALIZED = false;
+	/** this helper can create text annotations from text. */
     protected final TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
 
 	/**
@@ -79,7 +80,7 @@ public class SimpleGazetteerAnnotatorTest {
 	 */
 	@Test
 	public void testMultiThreading() throws IOException, URISyntaxException, AnnotatorException {
-		final SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/");
+		final SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", IS_LAZILY_INITIALIZED);
 		class TestThread extends Thread {
 			Throwable throwable;
 			public void run() {
@@ -153,7 +154,7 @@ public class SimpleGazetteerAnnotatorTest {
 	 */
 	@Test
 	public void testAddView() throws IOException, URISyntaxException, AnnotatorException {
-		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/");
+		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", false);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
 		TextAnnotation ta = tab.createTextAnnotation("I hail from the university of illinois at champaign urbana.");
@@ -177,7 +178,7 @@ public class SimpleGazetteerAnnotatorTest {
 		assertEquals(c4.getLabel(),"places(IC)");
 		assertEquals(c5.getLabel(),"places(IC)");
 		
-		sga = new SimpleGazetteerAnnotator(4, "/testgazetteers");
+		sga = new SimpleGazetteerAnnotator(4, "/testgazetteers", false);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
 		ta = tab.createTextAnnotation("I hail from the university of illinois at champaign urbana.");
@@ -211,25 +212,25 @@ public class SimpleGazetteerAnnotatorTest {
 	}
 
 	/**
-	 * Test method for {@link edu.illinois.cs.cogcomp.edison.annotators.SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(java.lang.String)}.
+	 * Test method for {@link SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(String, boolean)}.
 	 * @throws URISyntaxException 
 	 * @throws IOException 
 	 */
 	@Test
 	public void testSimpleGazetteerAnnotatorString() throws IOException, URISyntaxException {
-		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator("/testgazetteers/");
+		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator("/testgazetteers/", false);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
 	}
 
 	/**
-	 * Test method for {@link edu.illinois.cs.cogcomp.edison.annotators.SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(int, java.lang.String)}.
+	 * Test method for {@link edu.illinois.cs.cogcomp.edison.annotators.SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(int, java.lang.String, boolean}.
 	 * @throws URISyntaxException 
 	 * @throws IOException 
 	 */
 	@Test
 	public void testSimpleGazetteerAnnotatorIntString() throws IOException, URISyntaxException {
-		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/");
+		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", false);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
 	}

--- a/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotatorTest.java
+++ b/edison/src/test/java/edu/illinois/cs/cogcomp/edison/annotators/SimpleGazetteerAnnotatorTest.java
@@ -19,7 +19,11 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Properties;
 
+import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
+import edu.illinois.cs.cogcomp.edison.config.SimpleGazetteerAnnotatorConfigurator;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -45,11 +49,18 @@ public class SimpleGazetteerAnnotatorTest {
 	/** this helper can create text annotations from text. */
     protected final TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder(new StatefulTokenizer());
 
+
+    private static ResourceManager defaultRm;
 	/**
 	 * @throws java.lang.Exception
 	 */
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
+        Properties props = new Properties();
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, Configurator.FALSE);
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES.key, "/testgazetteers/" );
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.PHRASE_LENGTH.key, "6" );
+        defaultRm = new ResourceManager(props);
 	}
 
 	/**
@@ -80,7 +91,7 @@ public class SimpleGazetteerAnnotatorTest {
 	 */
 	@Test
 	public void testMultiThreading() throws IOException, URISyntaxException, AnnotatorException {
-		final SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", IS_LAZILY_INITIALIZED);
+		final SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator( defaultRm );
 		class TestThread extends Thread {
 			Throwable throwable;
 			public void run() {
@@ -154,7 +165,7 @@ public class SimpleGazetteerAnnotatorTest {
 	 */
 	@Test
 	public void testAddView() throws IOException, URISyntaxException, AnnotatorException {
-		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", false);
+		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(defaultRm);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
 		TextAnnotation ta = tab.createTextAnnotation("I hail from the university of illinois at champaign urbana.");
@@ -177,8 +188,12 @@ public class SimpleGazetteerAnnotatorTest {
 		assertEquals(c3.getLabel(),"places(IC)");
 		assertEquals(c4.getLabel(),"places(IC)");
 		assertEquals(c5.getLabel(),"places(IC)");
-		
-		sga = new SimpleGazetteerAnnotator(4, "/testgazetteers", false);
+
+        Properties props = new Properties();
+        props.setProperty( SimpleGazetteerAnnotatorConfigurator.PHRASE_LENGTH.key, "4" );
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES.key, "/testgazetteers/");
+        props.setProperty(SimpleGazetteerAnnotatorConfigurator.IS_LAZILY_INITIALIZED.key,  SimpleGazetteerAnnotatorConfigurator.FALSE );
+		sga = new SimpleGazetteerAnnotator(new ResourceManager( props ));
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
 		ta = tab.createTextAnnotation("I hail from the university of illinois at champaign urbana.");
@@ -212,26 +227,30 @@ public class SimpleGazetteerAnnotatorTest {
 	}
 
 	/**
-	 * Test method for {@link SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(String, boolean)}.
+	 * Test method for {@link SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(ResourceManager)}.
 	 * @throws URISyntaxException 
 	 * @throws IOException 
 	 */
 	@Test
 	public void testSimpleGazetteerAnnotatorString() throws IOException, URISyntaxException {
-		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator("/testgazetteers/", false);
+        Properties props = new Properties();
+        props.setProperty( SimpleGazetteerAnnotatorConfigurator.PATH_TO_DICTIONARIES.key, "/testgazetteers/" );
+        props.setProperty( SimpleGazetteerAnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, SimpleGazetteerAnnotatorConfigurator.FALSE );
+        ResourceManager localRm = new SimpleGazetteerAnnotatorConfigurator().getConfig( new ResourceManager(props));
+		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(localRm);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
 		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
 	}
 
-	/**
-	 * Test method for {@link edu.illinois.cs.cogcomp.edison.annotators.SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(int, java.lang.String, boolean}.
-	 * @throws URISyntaxException 
-	 * @throws IOException 
-	 */
-	@Test
-	public void testSimpleGazetteerAnnotatorIntString() throws IOException, URISyntaxException {
-		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", false);
-		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
-		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
-	}
+//	/**
+//	 * Test method for {@link edu.illinois.cs.cogcomp.edison.annotators.SimpleGazetteerAnnotator#SimpleGazetteerAnnotator(int, java.lang.String, boolean}.
+//	 * @throws URISyntaxException
+//	 * @throws IOException
+//	 */
+//	@Test
+//	public void testSimpleGazetteerAnnotatorIntString() throws IOException, URISyntaxException {
+//		SimpleGazetteerAnnotator sga = new SimpleGazetteerAnnotator(6, "/testgazetteers/", false);
+//		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionaries.size() == 1);
+//		assertTrue ("Wrong number of dictionaries loaded.",sga.dictionariesIgnoreCase.size() == 1);
+//	}
 }

--- a/lemmatizer/pom.xml
+++ b/lemmatizer/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-edison</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.stanford.nlp</groupId>

--- a/lemmatizer/pom.xml
+++ b/lemmatizer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-edison</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.stanford.nlp</groupId>

--- a/lemmatizer/pom.xml
+++ b/lemmatizer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-edison</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <dependency>
             <groupId>edu.stanford.nlp</groupId>

--- a/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
+++ b/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
@@ -86,6 +86,7 @@ public class IllinoisLemmatizer extends Annotator {
         toStanford.put("them", "they");
         toStanford.put("me", "i");
         toStanford.put("an", "a");
+        setIsInitialized();
     }
 
     private void loadExceptionMap() {
@@ -179,6 +180,8 @@ public class IllinoisLemmatizer extends Annotator {
 
     public String getLemma(String word, String pos) {
 
+        if ( !isInitialized() )
+            throw new IllegalStateException( "Not initialized! are you using lazy initialization? Need to call 'initialize()' before calling this method." );
         word = word.toLowerCase();
 
         // look at file

--- a/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
+++ b/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
@@ -55,7 +55,6 @@ public class IllinoisLemmatizer extends Annotator {
     public IllinoisLemmatizer(boolean isLazilyInitialized) {
 
         super(ViewNames.LEMMA, new String[] {ViewNames.POS}, isLazilyInitialized, new LemmatizerConfigurator().getDefaultConfig() );
-        initialize();
     }
 
     public IllinoisLemmatizer(ResourceManager rm) {

--- a/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
+++ b/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
@@ -20,6 +20,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TokenLabelView
 import edu.illinois.cs.cogcomp.core.io.IOUtils;
 import edu.illinois.cs.cogcomp.core.io.LineIO;
 import edu.illinois.cs.cogcomp.core.transformers.ITransformer;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.nlp.utilities.POSUtils;
 
@@ -49,16 +50,20 @@ public class IllinoisLemmatizer extends Annotator {
     private static boolean useStanford_default = false;
 
     public IllinoisLemmatizer() {
-        super(ViewNames.LEMMA, new String[] {ViewNames.POS});
-        initialize(new LemmatizerConfigurator().getDefaultConfig());
+        this(true);
+    }
+    public IllinoisLemmatizer(boolean isLazilyInitialized) {
+
+        super(ViewNames.LEMMA, new String[] {ViewNames.POS}, isLazilyInitialized, new LemmatizerConfigurator().getDefaultConfig() );
+        initialize();
     }
 
     public IllinoisLemmatizer(ResourceManager rm) {
-        super(ViewNames.LEMMA, new String[] {ViewNames.POS});
-        initialize(new LemmatizerConfigurator().getConfig(rm));
+        super(ViewNames.LEMMA, new String[] {ViewNames.POS}, rm.getBoolean(Configurator.IS_LAZILY_INITIALIZED.key, Configurator.TRUE ), rm );
     }
 
-    private void initialize(ResourceManager rm) {
+    public void initialize() {
+        ResourceManager rm = super.nonDefaultRm;
         this.useStanford = rm.getBoolean(LemmatizerConfigurator.USE_STNFRD_CONVENTIONS.key);
         wnLemmaReader = new WordnetLemmaReader(rm.getString(LemmatizerConfigurator.WN_PATH.key));
         loadVerbMap();

--- a/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
+++ b/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/IllinoisLemmatizer.java
@@ -67,13 +67,13 @@ public class IllinoisLemmatizer extends Annotator {
 
     /**
      * Override default config parameters with properties in rm. Is lazily initialized by default.
-     * @param rm non-default configuration params
+     * @param nonDefaultRm non-default configuration params
      */
-    public IllinoisLemmatizer(ResourceManager rm) {
+    public IllinoisLemmatizer(ResourceManager nonDefaultRm) {
         super(ViewNames.LEMMA,
                 new String[] {ViewNames.POS},
-                rm.getBoolean(AnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, Configurator.TRUE ),
-                rm );
+                nonDefaultRm.getBoolean(AnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, Configurator.TRUE ),
+                new LemmatizerConfigurator().getConfig(nonDefaultRm) );
     }
 
     public static List<String> readFromClasspath(String filename) {

--- a/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerConfigurator.java
+++ b/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerConfigurator.java
@@ -10,19 +10,18 @@
  */
 package edu.illinois.cs.cogcomp.nlp.lemmatizer;
 
-import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
+import edu.illinois.cs.cogcomp.annotation.AnnotatorConfigurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.Property;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 
 /**
  * Lemmatizer constructor parameters Created by mssammon on 1/5/16.
  */
-public class LemmatizerConfigurator extends Configurator {
+public class LemmatizerConfigurator extends AnnotatorConfigurator {
 
     public final static Property WN_PATH = new Property("wnPath", "wordnet-dict");
     public final static Property USE_STNFRD_CONVENTIONS = new Property("useStanfordConventions",
             FALSE);
-
     /**
      * get a ResourceManager object with the default key/value pairs for this configurator
      *

--- a/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerConfigurator.java
+++ b/lemmatizer/src/main/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerConfigurator.java
@@ -22,6 +22,7 @@ public class LemmatizerConfigurator extends AnnotatorConfigurator {
     public final static Property WN_PATH = new Property("wnPath", "wordnet-dict");
     public final static Property USE_STNFRD_CONVENTIONS = new Property("useStanfordConventions",
             FALSE);
+    public final static Property LEMMA_LAZY_INITIALIZE = new Property( AnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, TRUE );
     /**
      * get a ResourceManager object with the default key/value pairs for this configurator
      *
@@ -29,7 +30,7 @@ public class LemmatizerConfigurator extends AnnotatorConfigurator {
      */
     @Override
     public ResourceManager getDefaultConfig() {
-        Property[] props = {WN_PATH, USE_STNFRD_CONVENTIONS};
+        Property[] props = {WN_PATH, USE_STNFRD_CONVENTIONS, LEMMA_LAZY_INITIALIZE};
         return new ResourceManager(generateProperties(props));
     }
 }

--- a/lemmatizer/src/test/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerPlainTest.java
+++ b/lemmatizer/src/test/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerPlainTest.java
@@ -37,6 +37,7 @@ public class LemmatizerPlainTest {
     @Test
     public void test() {
         IllinoisLemmatizer lem = new IllinoisLemmatizer();
+
         ArrayList<String> lemmas = new ArrayList<>();
 
         for (String token : input) {

--- a/lemmatizer/src/test/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerTATest.java
+++ b/lemmatizer/src/test/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerTATest.java
@@ -53,11 +53,13 @@ public class LemmatizerTATest {
         // set non-default lemmatizer constructor params
         props.setProperty(LemmatizerConfigurator.USE_STNFRD_CONVENTIONS.key,
                 LemmatizerConfigurator.TRUE);
-        ResourceManager rm = new ResourceManager(props);
+        // since we are calling
+        props.setProperty( LemmatizerConfigurator.IS_LAZILY_INITIALIZED.key, LemmatizerConfigurator.FALSE );
+
+        ResourceManager rm = new LemmatizerConfigurator().getConfig(new ResourceManager(props));
 
         IllinoisLemmatizer lem = new IllinoisLemmatizer( new LemmatizerConfigurator().getConfig(rm));
 
-        lem.initialize();
         String lemma = lem.getLemma("me", "PRP");
         assertTrue(lemma.equals("i"));
     }

--- a/lemmatizer/src/test/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerTATest.java
+++ b/lemmatizer/src/test/java/edu/illinois/cs/cogcomp/nlp/lemmatizer/LemmatizerTATest.java
@@ -53,8 +53,11 @@ public class LemmatizerTATest {
         // set non-default lemmatizer constructor params
         props.setProperty(LemmatizerConfigurator.USE_STNFRD_CONVENTIONS.key,
                 LemmatizerConfigurator.TRUE);
-        IllinoisLemmatizer lem = new IllinoisLemmatizer(new ResourceManager(props));
+        ResourceManager rm = new ResourceManager(props);
 
+        IllinoisLemmatizer lem = new IllinoisLemmatizer( new LemmatizerConfigurator().getConfig(rm));
+
+        lem.initialize();
         String lemma = lem.getLemma("me", "PRP");
         assertTrue(lemma.equals("i"));
     }

--- a/ner/pom.xml
+++ b/ner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
         <!-- Contains the gazetteers and Brown clusters -->
         <dependency>

--- a/ner/pom.xml
+++ b/ner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <!-- Contains the gazetteers and Brown clusters -->
         <dependency>

--- a/ner/pom.xml
+++ b/ner/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
         <!-- Contains the gazetteers and Brown clusters -->
         <dependency>

--- a/ner/src/main/java/edu/illinois/cs/cogcomp/ner/NERAnnotator.java
+++ b/ner/src/main/java/edu/illinois/cs/cogcomp/ner/NERAnnotator.java
@@ -10,6 +10,7 @@
  */
 package edu.illinois.cs.cogcomp.ner;
 
+import edu.illinois.cs.cogcomp.annotation.AnnotatorConfigurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
 import edu.illinois.cs.cogcomp.ner.ExpressiveFeatures.ExpressiveFeaturesAnnotator;
 import edu.illinois.cs.cogcomp.ner.InferenceMethods.Decoder;
@@ -39,17 +40,14 @@ import java.util.Properties;
  */
 public class NERAnnotator extends Annotator {
 
-    /** our specific logger. */
-    private final Logger logger = LoggerFactory.getLogger(NERAnnotator.class);
-
-    /** the level one tagger. */
-    private NETaggerLevel1 t1 = null;
-
-    /** the level two tagger. */
-    private NETaggerLevel2 t2 = null;
-
     /** POS, shallow parsing are NOT required. */
     private static final String[] REQUIRED_VIEWS = {};
+    /** our specific logger. */
+    private final Logger logger = LoggerFactory.getLogger(NERAnnotator.class);
+    /** the level one tagger. */
+    private NETaggerLevel1 t1 = null;
+    /** the level two tagger. */
+    private NETaggerLevel2 t2 = null;
 
 
     /**
@@ -64,13 +62,18 @@ public class NERAnnotator extends Annotator {
 
     }
 
+    /**
+     * default constructor -- NER_CONLL models will be loaded. Lazily initialized by default.
+     * @param viewName name of view this annotator will add.
+     * @throws IOException
+     */
     public NERAnnotator(String viewName) throws IOException {
         this(new ResourceManager(new Properties()), viewName);
     }
 
     /**
      * Default behavior is to use lazy initialization; override with ResourceManager entry per the Configurator
-     *     property {@link Configurator#IS_LAZILY_INITIALIZED}
+     *     property {@link AnnotatorConfigurator#IS_LAZILY_INITIALIZED}
      *
      * @param nonDefaultRm specify properties to override defaults, including lazy initialization
      * @param viewName name of the view to add to the TextAnnotation (and for client to request)
@@ -78,17 +81,15 @@ public class NERAnnotator extends Annotator {
     public NERAnnotator(ResourceManager nonDefaultRm, String viewName) {
         super(viewName,
                 REQUIRED_VIEWS,
-                nonDefaultRm.getBoolean( Configurator.IS_LAZILY_INITIALIZED.key, Configurator.TRUE ),
+                nonDefaultRm.getBoolean( AnnotatorConfigurator.IS_LAZILY_INITIALIZED.key, Configurator.TRUE ),
                 nonDefaultRm);
     }
 
 
 
     @Override
-    public void initialize()
+    public void initialize( ResourceManager nerRm )
     {
-        ResourceManager nerRm = null;
-
         if (ViewNames.NER_ONTONOTES.equals(getViewName()))
             nerRm = new NerOntonotesConfigurator().getConfig(nonDefaultRm);
         else

--- a/ner/src/main/java/edu/illinois/cs/cogcomp/ner/NERAnnotator.java
+++ b/ner/src/main/java/edu/illinois/cs/cogcomp/ner/NERAnnotator.java
@@ -86,7 +86,12 @@ public class NERAnnotator extends Annotator {
     }
 
 
-
+    /**
+     * Superclass calls this method either on instantiation or at first call to getView().
+     * Logging has been disabled because non-static logger is not initialized at the time this is called if
+     *   non-lazy initialization is specified.
+     * @param nerRm configuration parameters passed to constructor
+     */
     @Override
     public void initialize( ResourceManager nerRm )
     {
@@ -98,8 +103,8 @@ public class NERAnnotator extends Annotator {
         ParametersForLbjCode.currentParameters.forceNewSentenceOnLineBreaks = false;
         Parameters.readConfigAndLoadExternalData(nerRm);
 
-        logger.info("Reading model file: {}",
-                ParametersForLbjCode.currentParameters.pathToModelFile + ".level1");
+//        logger.info("Reading model file: {}",
+//                ParametersForLbjCode.currentParameters.pathToModelFile + ".level1");
         NETaggerLevel1 tagger1 =
                 new NETaggerLevel1(ParametersForLbjCode.currentParameters.pathToModelFile
                         + ".level1", ParametersForLbjCode.currentParameters.pathToModelFile
@@ -107,8 +112,8 @@ public class NERAnnotator extends Annotator {
 
         NETaggerLevel2 tagger2 = null;
         if (ParametersForLbjCode.currentParameters.featuresToUse.containsKey("PredictionsLevel1")) {
-            logger.info("Reading model file: {}",
-                    ParametersForLbjCode.currentParameters.pathToModelFile + ".level2");
+//            logger.info("Reading model file: {}",
+//                    ParametersForLbjCode.currentParameters.pathToModelFile + ".level2");
             tagger2 =
                     new NETaggerLevel2(ParametersForLbjCode.currentParameters.pathToModelFile
                             + ".level2", ParametersForLbjCode.currentParameters.pathToModelFile

--- a/ner/src/main/java/edu/illinois/cs/cogcomp/ner/config/NerBaseConfigurator.java
+++ b/ner/src/main/java/edu/illinois/cs/cogcomp/ner/config/NerBaseConfigurator.java
@@ -160,6 +160,8 @@ public class NerBaseConfigurator extends Configurator {
 
         props.setProperty(RANDOM_NOISE_LEVEL, DEFAULT_RANDOM_NOISE_LEVEL);
         props.setProperty(OMISSION_RATE, DEFAULT_OMISSION_RATE);
+        props.setProperty( Configurator.IS_LAZILY_INITIALIZED.key, TRUE );
+
         return new ResourceManager(props);
     }
 }

--- a/ner/src/main/java/edu/illinois/cs/cogcomp/ner/config/NerBaseConfigurator.java
+++ b/ner/src/main/java/edu/illinois/cs/cogcomp/ner/config/NerBaseConfigurator.java
@@ -10,8 +10,8 @@
  */
 package edu.illinois.cs.cogcomp.ner.config;
 
+import edu.illinois.cs.cogcomp.annotation.AnnotatorConfigurator;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
-import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 
 import java.util.Properties;
@@ -25,7 +25,7 @@ import java.util.Properties;
  * individually, and the client will use the inherited {#getConfig( ResourceManager rm )} method to
  * override only those values that conflict with defaults. Created by mssammon on 10/14/15.
  */
-public class NerBaseConfigurator extends Configurator {
+public class NerBaseConfigurator extends AnnotatorConfigurator {
 
     public final static String PATH_TO_MODEL = "pathToModelFile";
     public final static String VIEW_NAME = "viewName";
@@ -72,7 +72,8 @@ public class NerBaseConfigurator extends Configurator {
 
     public final static String RANDOM_NOISE_LEVEL = "randomNoiseLevel";
     public final static String OMISSION_RATE = "omissionRate";
-
+    public final static String DEFAULT_MIN_CONFIDENCE_PREDICTIONS_1 = "0.0";
+    public final static String DEFAULT_MIN_CONFIDENCE_PREDICTIONS_2 = "0.0";
     private final static String DEFAULT_BROWN_CLUSTER_PATHS = "1";
     private final static String DEFAULT_IS_LOWERCASE_BROWN_CLUSTERS = "false false false";
     private final static String DEFAULT_PATHS_TO_BROWN_CLUSTERS =
@@ -81,7 +82,6 @@ public class NerBaseConfigurator extends Configurator {
     private final static String DEFAULT_GAZETTEER_FEATURES = "1";
     private final static String DEFAULT_PATHS_TO_GAZETTEERS = "gazetteers";
     private final static String DEFAULT_WORD_EMBEDDINGS = "0";
-
     private final static String DEFAULT_MODEL_PATH = "ner/models";
     private final static String DEFAULT_FORMS = "1";
     private final static String DEFAULT_PHRASE_LENGTH = "5";
@@ -96,7 +96,6 @@ public class NerBaseConfigurator extends Configurator {
     private final static String DEFAULT_AGGREGATE_GAZETTEER = "0";
     private final static String DEFAULT_PREV_TAGS_FOR_CONTEXT = "1";
     private final static String DEFAULT_PREDICTIONS_1 = "1";
-
     // private final static String DEFAULT_BEAM_SIZE = "5";
     private final static String DEFAULT_FORCE_LINE_BREAKS = TRUE;
     private final static String DEFAULT_LABELS = "PER ORG LOC MISC";
@@ -106,8 +105,6 @@ public class NerBaseConfigurator extends Configurator {
     private final static String DEFAULT_PATH_TO_TOKEN_NORM_DATA =
             "brown-clusters/brown-english-wikitext.case-intact.txt-c1000-freq10-v3.txt";
     private final static String DEFAULT_SORT_FILES_LEXICALLY = TRUE;
-    public final static String DEFAULT_MIN_CONFIDENCE_PREDICTIONS_1 = "0.0";
-    public final static String DEFAULT_MIN_CONFIDENCE_PREDICTIONS_2 = "0.0";
     private final static String DEFAULT_TREAT_ALL_FILES_AS_ONE = TRUE;
     private final static String DEFAULT_DEBUG = FALSE;
     private final static String DEFAULT_MODEL_NAME = "CoNLL";
@@ -160,7 +157,7 @@ public class NerBaseConfigurator extends Configurator {
 
         props.setProperty(RANDOM_NOISE_LEVEL, DEFAULT_RANDOM_NOISE_LEVEL);
         props.setProperty(OMISSION_RATE, DEFAULT_OMISSION_RATE);
-        props.setProperty( Configurator.IS_LAZILY_INITIALIZED.key, TRUE );
+        props.setProperty( IS_LAZILY_INITIALIZED.key, TRUE );
 
         return new ResourceManager(props);
     }

--- a/ner/src/main/java/edu/illinois/cs/cogcomp/ner/config/NerOntonotesConfigurator.java
+++ b/ner/src/main/java/edu/illinois/cs/cogcomp/ner/config/NerOntonotesConfigurator.java
@@ -10,6 +10,7 @@
  */
 package edu.illinois.cs.cogcomp.ner.config;
 
+import edu.illinois.cs.cogcomp.annotation.AnnotatorConfigurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.Configurator;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 
@@ -20,7 +21,7 @@ import java.util.Properties;
  *
  * Created by mssammon on 10/15/15.
  */
-public class NerOntonotesConfigurator extends Configurator {
+public class NerOntonotesConfigurator extends AnnotatorConfigurator {
     private static final String DEFAULT_ONTONOTES_MODEL_PATH = "ner/models";
     private static final String ONTONOTES_LABEL_TYPES =
             "TIME LAW GPE NORP LANGUAGE PERCENT FAC PRODUCT ORDINAL LOC PERSON WORK_OF_ART MONEY DATE EVENT QUANTITY ORG CARDINAL";

--- a/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NERAnnotatorTest.java
+++ b/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NERAnnotatorTest.java
@@ -16,6 +16,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Properties;
 
+import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.Property;
 import edu.illinois.cs.cogcomp.ner.LbjTagger.RandomLabelGenerator;
 import edu.illinois.cs.cogcomp.ner.LbjTagger.TextChunkRepresentationManager;
@@ -140,7 +141,13 @@ public class NERAnnotatorTest {
 
     public void testResults() {
         TextAnnotation ta = tab.createTextAnnotation(TEST_INPUT);
-        View view = getView(ta);
+        View view = null;
+        try {
+            view = getView(ta);
+        } catch (AnnotatorException e) {
+            e.printStackTrace();
+            fail( e.getMessage() );
+        }
         for (Constituent c : view.getConstituents()) {
             assertTrue("No entity named \"" + c.toString() + "\"", entities.contains(c.toString()));
         }
@@ -176,19 +183,36 @@ public class NERAnnotatorTest {
 
         // make sure any lazy loading is done outside the performance test.
         TextAnnotation tat = tab.createTextAnnotation(TEST_INPUT);
-        getView(tat);
+        try {
+            getView(tat);
+        } catch (AnnotatorException e) {
+            e.printStackTrace();
+            fail( e.getMessage() );
+        }
         long expectedPerformance = this.measureMachinePerformance();
         System.out.println("Expect " + expectedPerformance);
         {
             TextAnnotation ta = tab.createTextAnnotation(TEST_INPUT);
-            View view = getView(ta);
+            View view = null;
+            try {
+                view = getView(ta);
+            } catch (AnnotatorException e) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
             assertTrue(view != null);
         }
         // start the performance test.
         long start = System.currentTimeMillis();
         for (int i = 0; i < SIZE; i++) {
             TextAnnotation ta = tab.createTextAnnotation(TEST_INPUT);
-            View view = getView(ta);
+            View view = null;
+            try {
+                view = getView(ta);
+            } catch (AnnotatorException e) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
             assertTrue(view != null);
             for (Constituent c : view.getConstituents()) {
                 assertTrue("No entity named \"" + c.toString() + "\"",
@@ -230,13 +254,23 @@ public class NERAnnotatorTest {
         public void run() {
             TextAnnotation ta1 = tab.createTextAnnotation(TEST_INPUT);
             {
-                view = getView(ta1);
+                try {
+                    view = getView(ta1);
+                } catch (AnnotatorException e) {
+                    e.printStackTrace();
+                    fail( e.getMessage() );
+                }
                 assertTrue(view != null);
             }
             long start = System.currentTimeMillis();
             for (int i = 0; i < duration; i++) {
                 TextAnnotation ta = tab.createTextAnnotation(TEST_INPUT);
-                view = getView(ta);
+                try {
+                    view = getView(ta);
+                } catch (AnnotatorException e) {
+                    e.printStackTrace();
+                    fail( e.getMessage() );
+                }
                 for (Constituent c : view.getConstituents()) {
                     if (!entities.contains(c.toString()))
                         error = "No entity named \"" + c.toString() + "\"";
@@ -291,7 +325,13 @@ public class NERAnnotatorTest {
     @Test
     public void testTokenization() {
         TextAnnotation ta = tab.createTextAnnotation(TOKEN_TEST);
-        View nerView = getView(ta);
+        View nerView = null;
+        try {
+            nerView = getView(ta);
+        } catch (AnnotatorException e) {
+            e.printStackTrace();
+            fail( e.getMessage() );
+        }
         assertEquals(nerView.getConstituents().size(), 2);
 
         String tokTestB =
@@ -299,7 +339,12 @@ public class NERAnnotatorTest {
                         + "nuclear waste, is released on parole after serving two-thirds of his four-year prison sentence.";
 
         ta = tab.createTextAnnotation(tokTestB);
-        nerView = getView(ta);
+        try {
+            nerView = getView(ta);
+        } catch (AnnotatorException e) {
+            e.printStackTrace();
+            fail( e.getMessage() );
+        }
 
         assertEquals(3, nerView.getNumberOfConstituents());
     }
@@ -316,7 +361,13 @@ public class NERAnnotatorTest {
         // need to get any lazy data initialization out of the way to get a good read.
         {
             TextAnnotation ta = tab.createTextAnnotation(TEST_INPUT);
-            View view = getView(ta);
+            View view = null;
+            try {
+                view = getView(ta);
+            } catch (AnnotatorException e) {
+                e.printStackTrace();
+                fail( e.getMessage() );
+            }
             for (Constituent c : view.getConstituents()) {
                 assertTrue(entities.contains(c.toString()));
             }
@@ -349,8 +400,8 @@ public class NERAnnotatorTest {
         System.out.println("Average runtime is " + (avg / count));
     }
 
-    public static View getView(TextAnnotation ta) {
-        nerAnnotator.addView(ta);
+    public static View getView(TextAnnotation ta) throws AnnotatorException {
+        nerAnnotator.getView(ta);
         return ta.getView(nerAnnotator.getViewName());
     }
 

--- a/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NerInitTest.java
+++ b/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NerInitTest.java
@@ -10,6 +10,7 @@
  */
 package edu.illinois.cs.cogcomp.ner;
 
+import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
 import edu.illinois.cs.cogcomp.annotation.TextAnnotationBuilder;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
@@ -23,6 +24,7 @@ import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  *  A test that excludes big resource files for a quick assessment of basic NER behavior,
@@ -50,7 +52,12 @@ public class NerInitTest
         TextAnnotationBuilder tab = new TokenizerTextAnnotationBuilder( new StatefulTokenizer() );
         TextAnnotation ta = tab.createTextAnnotation(TESTSTR);
 
-        ner.addView( ta );
+        try {
+            ner.getView( ta );
+        } catch (AnnotatorException e) {
+            e.printStackTrace();
+            fail( e.getMessage() );
+        }
 
         assert( ta.hasView( ViewNames.NER_CONLL ) );
         assertEquals( ta.getView( ViewNames.NER_CONLL ).getConstituents().size(), 2 );

--- a/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NerOntonotesTest.java
+++ b/ner/src/test/java/edu/illinois/cs/cogcomp/ner/NerOntonotesTest.java
@@ -10,6 +10,7 @@
  */
 package edu.illinois.cs.cogcomp.ner;
 
+import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
 import edu.illinois.cs.cogcomp.annotation.TextAnnotationBuilder;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
@@ -22,6 +23,7 @@ import org.junit.Test;
 import java.util.Properties;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class NerOntonotesTest {
 
@@ -40,7 +42,12 @@ public class NerOntonotesTest {
 
         TextAnnotation taOnto = tab.createTextAnnotation("", "", TEST_INPUT);
 
-        nerOntonotes.addView(taOnto);
+        try {
+            nerOntonotes.getView(taOnto);
+        } catch (AnnotatorException e) {
+            e.printStackTrace();
+            fail( e.getMessage() );
+        }
         View v = taOnto.getView(nerOntonotes.getViewName());
 
         assertEquals(v.getConstituents().size(), 4);

--- a/pom.xml
+++ b/pom.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>edu.illinois.cs.cogcomp</groupId>
     <artifactId>illinois-cogcomp-nlp</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.58</version>
+    <version>3.0.59-SNAPSHOT</version>
 
     <modules>
         <module>core-utilities</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>edu.illinois.cs.cogcomp</groupId>
     <artifactId>illinois-cogcomp-nlp</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.59-SNAPSHOT</version>
+    <version>3.0.58</version>
 
     <modules>
         <module>core-utilities</module>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>edu.illinois.cs.cogcomp</groupId>
     <artifactId>illinois-cogcomp-nlp</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.58</version>
+    <version>3.0.59-SNAPSHOT</version>
 
     <modules>
         <module>core-utilities</module>

--- a/pos/pom.xml
+++ b/pos/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
 
         <dependency>

--- a/pos/pom.xml
+++ b/pos/pom.xml
@@ -1,8 +1,8 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pos/pom.xml
+++ b/pos/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSAnnotator.java
+++ b/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSAnnotator.java
@@ -16,6 +16,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.lbjava.nlp.Word;
 import edu.illinois.cs.cogcomp.lbjava.nlp.seg.Token;
 
@@ -41,27 +42,28 @@ public class POSAnnotator extends Annotator {
     private String sentencesfield = "sentences";
 
     /**
-     * do not lazily initialize by default.
+     * lazily initialize by default.
      */
     public POSAnnotator() {
         this(true);
     }
 
+    /**
+     * Constructor allowing choice whether or not to lazily initialize.
+     * @param lazilyInitialize  if 'true', load models only on first call to {@link Annotator#getView(TextAnnotation)}
+     */
     public POSAnnotator(boolean lazilyInitialize) {
         super(ViewNames.POS, new String[0], lazilyInitialize );
         tokensfield = ViewNames.TOKENS;
         sentencesfield = ViewNames.SENTENCE;
-        if ( !lazilyInitialize )
-            initialize();
     }
 
 
     @Override
-    public void initialize()
+    public void initialize(ResourceManager rm)
     {
         logger.info( "Initializing " + NAME );
         tagger = new POSTagger();
-        super.setIsInitialized();
     }
 
     /**
@@ -96,12 +98,6 @@ public class POSAnnotator extends Annotator {
 
         record.addView(ViewNames.POS, posView);
 
-    }
-
-
-    @Override
-    public String getViewName() {
-        return ViewNames.POS;
     }
 
 

--- a/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSAnnotator.java
+++ b/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSAnnotator.java
@@ -59,10 +59,13 @@ public class POSAnnotator extends Annotator {
     }
 
 
+    /**
+     * called by superclass either on instantiation, or on first call to getView().
+     * @param rm configuration parameters
+     */
     @Override
     public void initialize(ResourceManager rm)
     {
-        logger.info( "Initializing " + NAME );
         tagger = new POSTagger();
     }
 

--- a/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSAnnotator.java
+++ b/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSAnnotator.java
@@ -34,18 +34,35 @@ import java.util.List;
  */
 public class POSAnnotator extends Annotator {
 
-    private static final String NAME = "illinoispos";
+    private static final String NAME =  POSAnnotator.class.getCanonicalName();
     private final Logger logger = LoggerFactory.getLogger(POSAnnotator.class);
-    private final POSTagger tagger = new POSTagger();
+    private POSTagger tagger = null;
     private String tokensfield = "tokens";
     private String sentencesfield = "sentences";
 
+    /**
+     * do not lazily initialize by default.
+     */
     public POSAnnotator() {
-        super(ViewNames.POS, new String[0]);
-        tokensfield = ViewNames.TOKENS;
-        sentencesfield = ViewNames.SENTENCE;
+        this(true);
     }
 
+    public POSAnnotator(boolean lazilyInitialize) {
+        super(ViewNames.POS, new String[0], lazilyInitialize );
+        tokensfield = ViewNames.TOKENS;
+        sentencesfield = ViewNames.SENTENCE;
+        if ( !lazilyInitialize )
+            initialize();
+    }
+
+
+    @Override
+    public void initialize()
+    {
+        logger.info( "Initializing " + NAME );
+        tagger = new POSTagger();
+        super.setIsInitialized();
+    }
 
     /**
      * annotates TextAnnotation with POS view and adds it to the TextAnnotation.
@@ -57,6 +74,7 @@ public class POSAnnotator extends Annotator {
         if (!record.hasView(tokensfield) && !record.hasView(sentencesfield)) {
             throw new AnnotatorException("Record must be tokenized and sentence split first");
         }
+
         long startTime = System.currentTimeMillis();
         List<Token> input = LBJavaUtils.recordToLBJTokens(record);
 

--- a/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSTrain.java
+++ b/pos/src/main/java/edu/illinois/cs/cogcomp/pos/POSTrain.java
@@ -124,7 +124,7 @@ public class POSTrain {
         mikheevTable.save();
         taggerKnown.save();
         taggerUnknown.save();
-        System.out.println("Done training");
+        System.out.println("Done training, wrote models to disk.");
     }
 
     public static void main(String[] args) {

--- a/pos/src/test/java/edu/illinois/cs/cogcomp/pos/tests/TestDiff.java
+++ b/pos/src/test/java/edu/illinois/cs/cogcomp/pos/tests/TestDiff.java
@@ -104,7 +104,7 @@ public class TestDiff {
         TextAnnotation record =
                 BasicTextAnnotationBuilder.createTextAnnotationFromTokens(refTokens);
         try {
-            annotator.addView(record);
+            annotator.getView(record);
         } catch (AnnotatorException e) {
             fail("AnnotatorException thrown!\n" + e.getMessage());
         }

--- a/tokenizer/pom.xml
+++ b/tokenizer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/tokenizer/pom.xml
+++ b/tokenizer/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.58</version>
+        <version>3.0.59-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.58</version>
+            <version>3.0.59-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/tokenizer/pom.xml
+++ b/tokenizer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.59-SNAPSHOT</version>
+        <version>3.0.58</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.59-SNAPSHOT</version>
+            <version>3.0.58</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Changed Annotator to allow lazy initialization. Key is that all users must call "getView()" and not "addView()", b.c. "getView()" is the public, generic way to get the view and "addView()" is the annotator-specific implementation, and I wanted a uniform mechanism.... I changed a number of Annotators (POS, Chunker, NER, Lemmatizer, SimpleGazetteerAnnotator) to use lazy init by default, and added some basic tests.