### PR TITLE
updated AnnotatorService API, added attributes to Relation

### DIFF
--- a/chunker/pom.xml
+++ b/chunker/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-pos</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>

--- a/core-utilities/pom.xml
+++ b/core-utilities/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/AnnotatorService.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/AnnotatorService.java
@@ -12,6 +12,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.View;
 import edu.illinois.cs.cogcomp.nlp.tokenizer.Tokenizer;
 
+import javax.xml.soap.Text;
 import java.util.Set;
 
 /**
@@ -148,4 +149,36 @@ public interface AnnotatorService {
      * @throws AnnotatorException If this AnnotatorService cannot provide this {@code viewName},
      */
     boolean addView(TextAnnotation ta, String viewName) throws AnnotatorException;
+
+
+    /**
+     * Add a new {@link Annotator} to the service. All prerequisite views must already be provided by other annotators
+     *    known to this {@link edu.illinois.cs.cogcomp.annotation.AnnotatorService}.
+     * @param annotator the {@link Annotator} to be added.
+     * @throws {@link AnnotatorException} if the annotator requires views that cannot be satisfied.
+     */
+    void addAnnotator( Annotator annotator ) throws AnnotatorException;
+
+
+    /**
+     * Return a set containing the names of all {@link edu.illinois.cs.cogcomp.core.datastructures.textannotation.View}s
+     *     that this service can provide.
+     * @return a set of view names corresponding to annotators known to this AnnotatorService
+     */
+    Set< String > getAvailableViews();
+
+
+    /**
+     * Add the specified views to the TextAnnotation argument. This is useful when TextAnnotation objects are
+     *    built independently of the service, perhaps by a different system component (e.g. a corpus reader).
+     * If so specified, overwrite existing views.
+     *
+     * @param ta The {@link edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation} to annotate
+     * @param replaceExistingViews if 'true', annotate a
+     *                              {@link edu.illinois.cs.cogcomp.core.datastructures.textannotation.View} even if
+     *                              it is already present in the ta argument, replacing the original corresponding View.
+     * @return a reference to the updated TextAnnotation
+     */
+    TextAnnotation annotateTextAnnotation(TextAnnotation ta, boolean replaceExistingViews ) throws AnnotatorException;
+
 }

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
@@ -27,21 +27,14 @@ public class Constituent implements Serializable {
     protected final double constituentScore;
 
     protected final TextAnnotation textAnnotation;
-
-    protected Map<String, String> attributes;
-
     protected final IntPair span; // span start/end token offsets
-
     // Curator-style offsets -- end char offset numbers position AFTER
     // constituent
     protected final int startCharOffset;
     protected final int endCharOffset;
-
     protected final List<Relation> outgoingRelations;
     protected final List<Relation> incomingRelations;
-
     protected final int label;
-
     /**
      * This indicates whether the element {@code Constituent#constituentTokens} is a two element
      * list consisting of a start and an end tokenId, specifying a span, instead of explicitly
@@ -50,6 +43,7 @@ public class Constituent implements Serializable {
     // protected boolean useConstituentTokensAsSpan;
 
     protected final String viewName;
+    protected Map<String, String> attributes;
 
     /**
      * start, end offsets are token indexes, and use one-past-the-end indexing -- so a one-token
@@ -355,6 +349,9 @@ public class Constituent implements Serializable {
         return (this.attributes != null) && (attributes.containsKey(key));
     }
 
+    /**
+     * @return
+     */
     @Override
     public int hashCode() {
 
@@ -373,7 +370,6 @@ public class Constituent implements Serializable {
             hashCode += relation.getRelationName().hashCode() * 3;
             hashCode += relation.getSource().getStartSpan() * 11;
             hashCode += relation.getSource().getEndSpan() * 17;
-
         }
 
         for (Relation relation : this.getOutgoingRelations()) {
@@ -383,6 +379,7 @@ public class Constituent implements Serializable {
             hashCode += relation.getTarget().getEndSpan() * 19;
 
         }
+
 
         return hashCode;
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Relation.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Relation.java
@@ -8,6 +8,10 @@
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Vivek Srikumar
@@ -17,12 +21,11 @@ import java.io.Serializable;
 public class Relation implements Serializable {
 
     private static final long serialVersionUID = -1005341815252250162L;
-
+    protected final int relationName;
     protected Constituent source;
     protected Constituent target;
-
     protected double score;
-    protected final int relationName;
+    protected Map<String, String> attributes;
 
     public Relation(String relationName, Constituent source, Constituent target, double score) {
 
@@ -52,7 +55,17 @@ public class Relation implements Serializable {
         if (!(obj instanceof Relation))
             return false;
 
+
         Relation r = (Relation) obj;
+
+        if (this.attributes == null && r.attributes != null)
+            return false;
+        if (this.attributes != null && r.attributes == null)
+            return false;
+
+        if (this.attributes != null && r.attributes != null)
+            if (!this.attributes.equals(r.attributes))
+                return false;
 
         return r.getRelationName().equals(this.relationName)
                 && r.getSource().equals(this.getSource()) && r.getTarget().equals(this.getTarget())
@@ -85,14 +98,56 @@ public class Relation implements Serializable {
         return target;
     }
 
+
+    public void setAttribute( String key, String value )
+    {
+        if ( null == attributes )
+            attributes = new HashMap<>();
+
+        attributes.put( key, value );
+    }
+
+
+    public String getAttribute(String key) {
+        if (attributes == null)
+            return null;
+        else
+            return attributes.get(key);
+    }
+
+    public Set<String> getAttributeKeys() {
+
+        if (this.attributes == null)
+            return new HashSet<>();
+        else
+            return this.attributes.keySet();
+    }
+
+    /**
+     * Removes all attributes from a Constituent.
+     */
+    public void removeAllAttributes() {
+        this.attributes = null;
+    }
+
+
     @Override
     public int hashCode() {
-        return this.getRelationName().hashCode() * 79 + this.getSource().hashCode() * 7
+        int hashCode =  this.getRelationName().hashCode() * 79 + this.getSource().hashCode() * 7
                 + this.getTarget().hashCode() * 13 + (new Double(this.getScore())).hashCode() * 17;
+        hashCode += (this.attributes == null ? 0 : this.attributes.hashCode() * 13);
+
+        return hashCode;
     }
 
     @Override
     public String toString() {
-        return source + "--" + getRelationName() + "--> " + target + "(" + getScore() + ")";
+        StringBuilder bldr = new StringBuilder( source.toString() );
+        bldr.append( "--" ).append( getRelationName() ).append("--> ");
+        bldr.append( target ).append("(").append( getScore() ).append( ")" );
+        return bldr.toString();
     }
+
+
+
 }

--- a/corpusreaders/pom.xml
+++ b/corpusreaders/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/XmlFragmentWhitespacingDocumentReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/XmlFragmentWhitespacingDocumentReader.java
@@ -91,7 +91,7 @@ public class XmlFragmentWhitespacingDocumentReader extends AbstractIncrementalCo
         FilenameFilter filter = new FilenameFilter() {
             @Override
             public boolean accept(File dir, String name) {
-                return name.endsWith(".cmp.txt");
+                return true;
             }
         };
 

--- a/curator/pom.xml
+++ b/curator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
 
         <!-- Curator-related dependencies -->

--- a/edison/pom.xml
+++ b/edison/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -26,13 +26,13 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-corpusreaders</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <!-- Used only in utilities.CreateTestTAResource -->
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-curator</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <!-- Used only in features.FeatureUtilities to convert to LBJava-based feature vectors -->

--- a/lemmatizer/pom.xml
+++ b/lemmatizer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-edison</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.stanford.nlp</groupId>

--- a/ner/pom.xml
+++ b/ner/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -23,12 +23,12 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-tokenizer</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <!-- Contains the gazetteers and Brown clusters -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>edu.illinois.cs.cogcomp</groupId>
     <artifactId>illinois-cogcomp-nlp</artifactId>
     <packaging>pom</packaging>
-    <version>3.0.61</version>
+    <version>3.0.63-SNAPSHOT</version>
 
     <modules>
         <module>core-utilities</module>

--- a/pos/pom.xml
+++ b/pos/pom.xml
@@ -2,7 +2,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/tokenizer/pom.xml
+++ b/tokenizer/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>illinois-cogcomp-nlp</artifactId>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <version>3.0.61</version>
+        <version>3.0.63-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-core-utilities</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>edu.illinois.cs.cogcomp</groupId>
             <artifactId>illinois-curator</artifactId>
-            <version>3.0.61</version>
+            <version>3.0.63-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
added methods to make AnnotatorService more flexible: get set of views it can provide, allow a new annotator to be added, and allow annotation of an existing TextAnnotation (rather than creating one from scratch or adding views one at a time)
-- this latter is a convenience method and could be removed, provided the getAvailableViews() method is included