### PR TITLE
overloaded writeModelsToDisk

### DIFF
--- a/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerTrain.java
+++ b/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerTrain.java
@@ -13,6 +13,7 @@ import edu.illinois.cs.cogcomp.chunker.utils.CoNLL2000Parser;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.lbjava.parse.LinkedVector;
 import edu.illinois.cs.cogcomp.lbjava.parse.Parser;
+import edu.illinois.cs.cogcomp.core.io.IOUtils;
 
 /**
  * Trains chunker models with user specified labeled data in the CoNLL2000 format. Similar to
@@ -91,8 +92,9 @@ public class ChunkerTrain {
         System.out.println("Done training, models are in " + rm.getString("modelDirPath"));
     }
     public void writeModelsToDisk(String dir, String modelName){
-        chunker.write(dir + modelName + ".lc", dir + modelName + ".lex");
-        System.out.println("Done training, models are in " + dir+modelName+".lc (.lex)");
+        IOUtils.mkdir(dir);
+        chunker.write(dir + File.separator + modelName + ".lc", dir + File.separator + modelName + ".lex");
+        System.out.println("Done training, models are in " + dir+File.separator+modelName+".lc (.lex)");
     }
     public static void main(String[] args) {
         ChunkerTrain trainer = new ChunkerTrain();

--- a/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerTrain.java
+++ b/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerTrain.java
@@ -90,7 +90,10 @@ public class ChunkerTrain {
         chunker.save();
         System.out.println("Done training, models are in " + rm.getString("modelDirPath"));
     }
-
+    public void writeModelsToDisk(String dir, String modelName){
+        chunker.write(dir + modelName + ".lc", dir + modelName + ".lex");
+        System.out.println("Done training, models are in " + dir+modelName+".lc (.lex)");
+    }
     public static void main(String[] args) {
         ChunkerTrain trainer = new ChunkerTrain();
         trainer.trainModels();

--- a/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerTrain.java
+++ b/chunker/src/main/java/edu/illinois/cs/cogcomp/chunker/main/ChunkerTrain.java
@@ -14,6 +14,7 @@ import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.lbjava.parse.LinkedVector;
 import edu.illinois.cs.cogcomp.lbjava.parse.Parser;
 import edu.illinois.cs.cogcomp.core.io.IOUtils;
+import java.io.File;
 
 /**
  * Trains chunker models with user specified labeled data in the CoNLL2000 format. Similar to


### PR DESCRIPTION
writeModelsToDisk now can also take user specified dir and model name as inputs.