### PR TITLE
ACE Reader fixes

### DIFF
--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
@@ -107,16 +107,14 @@ public class ACEReader extends TextAnnotationReader {
                 Integer.parseInt(extentConstituent
                         .getAttribute(ACEReader.EntityHeadStartCharOffset));
         int endCharOffset =
-                Integer.parseInt(extentConstituent.getAttribute(ACEReader.EntityHeadEndCharOffset));
-        int start_token = textAnnotation.getTokenIdFromCharacterOffset(startCharOffset);
-        int end_token = textAnnotation.getTokenIdFromCharacterOffset(endCharOffset);
+                Integer.parseInt(extentConstituent.getAttribute(ACEReader.EntityHeadEndCharOffset)) - 1;
+        int startToken = textAnnotation.getTokenIdFromCharacterOffset(startCharOffset);
+        int endToken = textAnnotation.getTokenIdFromCharacterOffset(endCharOffset);
 
-        if (start_token >= 0 && end_token >= 0 && !(end_token - start_token < 0)) {
-            // Be careful with the +1 in end_span below. Regular TextAnnotation likes the end_token
-            // number exclusive
+        if (startToken >= 0 && endToken >= 0 && !(endToken - startToken < 0)) {
             Constituent cons =
                     new Constituent(extentConstituent.getLabel(), 1.0, viewName, textAnnotation,
-                            start_token, end_token + 1);
+                            startToken, endToken + 1);
 
             for (String attributeKey : extentConstituent.getAttributeKeys()) {
                 cons.addAttribute(attributeKey, extentConstituent.getAttribute(attributeKey));
@@ -245,8 +243,10 @@ public class ACEReader extends TextAnnotationReader {
                     extentConstituent.addAttribute(EntityMentionLDCTypeAttribute, entityMention.ldcType);
                 }
 
+                // ACE Annotation have character offsets inclusive of start/end.
+                // Converting them to a one-after-then-end.
                 extentConstituent.addAttribute(EntityHeadStartCharOffset, entityMention.headStart + "");
-                extentConstituent.addAttribute(EntityHeadEndCharOffset, entityMention.headEnd + "");
+                extentConstituent.addAttribute(EntityHeadEndCharOffset, entityMention.headEnd + 1 + "");
 
                 entityView.addConstituent(extentConstituent);
 

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
@@ -89,7 +89,7 @@ public class ACEReader extends TextAnnotationReader {
 
         FilenameFilter apfFileFilter = new FilenameFilter() {
             public boolean accept(File directory, String fileName) {
-                return ( new File(directory + "/" + fileName).isDirectory() || fileName.endsWith(".apf.xml") );
+                return ( new File(directory + File.separator + fileName).isDirectory() || fileName.endsWith(".apf.xml") );
             }
         };
 

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReaderTests/ACEReaderParseTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReaderTests/ACEReaderParseTest.java
@@ -36,6 +36,9 @@ public class ACEReaderParseTest {
         String corpusHomeDir = "src/test/resources/ACE/ace2004/data/English";
         ACEReader reader = new ACEReader(corpusHomeDir, true);
         testReaderParse(reader, corpusHomeDir, 2);
+
+        reader.reset();
+        testReaderParse(reader, corpusHomeDir, 2);
     }
 
     @Ignore("ACE Dataset files will not be commited to repo.")
@@ -43,6 +46,9 @@ public class ACEReaderParseTest {
     public void test2005Dataset() throws Exception {
         String corpusHomeDir = "src/test/resources/ACE/ace2005/data/English";
         ACEReader reader = new ACEReader(corpusHomeDir, false);
+        testReaderParse(reader, corpusHomeDir, 6);
+
+        reader.reset();
         testReaderParse(reader, corpusHomeDir, 6);
     }
 
@@ -92,7 +98,7 @@ public class ACEReaderParseTest {
             numDocs++;
         }
 
-        assertEquals(numDocs, numberOfDocs);
+        assertEquals(numberOfDocs, numDocs);
     }
 
 

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReaderTests/SerializationTests.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReaderTests/SerializationTests.java
@@ -19,20 +19,18 @@ import org.junit.Test;
  */
 public class SerializationTests {
 
-    @Ignore("ACE Dataset files will not be commited to repo.")
     @Test
     public void test2004Dataset() throws Exception {
-        ACEReader reader = new ACEReader("src/test/resources/ACE/ace2004/data/English", true);
+        ACEReader reader = new ACEReader(ACEReaderParseTest.ACE2004CORPUS, true);
 
         for (TextAnnotation ta : reader) {
             testDocumentSerialization(ta);
         }
     }
 
-    @Ignore("ACE Dataset files will not be commited to repo.")
     @Test
     public void test2005Dataset() throws Exception {
-        ACEReader reader = new ACEReader("src/test/resources/ACE/ace2005/data/English", false);
+        ACEReader reader = new ACEReader(ACEReaderParseTest.ACE2005CORPUS, false);
 
         for (TextAnnotation ta : reader) {
             testDocumentSerialization(ta);

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/ace2004/bn/VOA20001231.2000.3520.apf.xml
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/ace2004/bn/VOA20001231.2000.3520.apf.xml
@@ -1,0 +1,270 @@
+<?xml version="1.0"?>
+<!DOCTYPE source_file SYSTEM "apf.v4.0.1.dtd">
+<source_file URI="VOA20001231.2000.3520.sgm" SOURCE="broadcast news" TYPE="text" VERSION="4.0" AUTHOR="LDC" ENCODING="UTF-8">
+<document DOCID="VOA20001231.2000.3520">
+<entity ID="VOA20001231.2000.3520-E1" TYPE="PER" CLASS="SPC">
+  <entity_mention ID="1-2" TYPE="PRO" LDCTYPE="PTV">
+    <extent>
+      <charseq START="249" END="265">most of the world</charseq>
+    </extent>
+    <head>
+      <charseq START="249" END="252">most</charseq>
+    </head>
+  </entity_mention>
+</entity>
+<entity ID="VOA20001231.2000.3520-E2" TYPE="PER" CLASS="SPC">
+  <entity_mention ID="2-1" TYPE="NAM" LDCTYPE="NAM" LDCATR="FALSE">
+    <extent>
+      <charseq START="65" END="89">Cuban leader Fidel Castro</charseq>
+    </extent>
+    <head>
+      <charseq START="78" END="89">Fidel Castro</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="2-3" TYPE="PRE" LDCTYPE="PRE" LDCATR="TRUE">
+    <extent>
+      <charseq START="65" END="76">Cuban leader</charseq>
+    </extent>
+    <head>
+      <charseq START="71" END="76">leader</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="2-16" TYPE="NAM" LDCTYPE="NAM" LDCATR="FALSE">
+    <extent>
+      <charseq START="755" END="770">President Castro</charseq>
+    </extent>
+    <head>
+      <charseq START="765" END="770">Castro</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="2-17" TYPE="PRE" LDCTYPE="PRE" LDCATR="TRUE">
+    <extent>
+      <charseq START="755" END="763">President</charseq>
+    </extent>
+    <head>
+      <charseq START="755" END="763">President</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="2-18" TYPE="PRO" LDCTYPE="PRO" LDCATR="FALSE">
+    <extent>
+      <charseq START="776" END="778">his</charseq>
+    </extent>
+    <head>
+      <charseq START="776" END="778">his</charseq>
+    </head>
+  </entity_mention>
+  <entity_attributes>
+    <name>
+      <charseq START="78" END="89">Fidel Castro</charseq>
+    </name>
+    <name>
+      <charseq START="765" END="770">Castro</charseq>
+    </name>
+  </entity_attributes>
+</entity>
+<entity ID="VOA20001231.2000.3520-E4" TYPE="GPE" SUBTYPE="Nation" CLASS="SPC">
+  <entity_mention ID="4-4" TYPE="PRE" LDCTYPE="PRE" ROLE="GPE" LDCATR="TRUE">
+    <extent>
+      <charseq START="65" END="69">Cuban</charseq>
+    </extent>
+    <head>
+      <charseq START="65" END="69">Cuban</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="4-5" TYPE="NOM" LDCTYPE="NOM" ROLE="LOC" LDCATR="FALSE">
+    <extent>
+      <charseq START="130" END="146">the
+island nation</charseq>
+    </extent>
+    <head>
+      <charseq START="141" END="146">nation</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="4-14" TYPE="NAM" LDCTYPE="NAM" ROLE="LOC" LDCATR="FALSE">
+    <extent>
+      <charseq START="736" END="814">Cuba though, where President Castro had his country sit out last
+year's revelry</charseq>
+    </extent>
+    <head>
+      <charseq START="736" END="739">Cuba</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="4-15" TYPE="PRO" LDCTYPE="WHQ" ROLE="LOC" LDCATR="FALSE">
+    <extent>
+      <charseq START="749" END="753">where</charseq>
+    </extent>
+    <head>
+      <charseq START="749" END="753">where</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="4-19" TYPE="NOM" LDCTYPE="NOM" ROLE="GPE" LDCATR="FALSE">
+    <extent>
+      <charseq START="776" END="786">his country</charseq>
+    </extent>
+    <head>
+      <charseq START="780" END="786">country</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="4-20" TYPE="PRO" LDCTYPE="PRO" ROLE="GPE" LDCATR="FALSE">
+    <extent>
+      <charseq START="817" END="820">they</charseq>
+    </extent>
+    <head>
+      <charseq START="817" END="820">they</charseq>
+    </head>
+  </entity_mention>
+  <entity_attributes>
+    <name>
+      <charseq START="736" END="739">Cuba</charseq>
+    </name>
+  </entity_attributes>
+</entity>
+<entity ID="VOA20001231.2000.3520-E6" TYPE="LOC" SUBTYPE="Land-Region-Natural" CLASS="SPC">
+  <entity_mention ID="6-6" TYPE="PRE" LDCTYPE="PRE">
+    <extent>
+      <charseq START="134" END="139">island</charseq>
+    </extent>
+    <head>
+      <charseq START="134" END="139">island</charseq>
+    </head>
+  </entity_mention>
+</entity>
+<entity ID="VOA20001231.2000.3520-E7" TYPE="GPE" SUBTYPE="Other" CLASS="SPC">
+  <entity_mention ID="7-7" TYPE="NOM" LDCTYPE="NOM" ROLE="GPE">
+    <extent>
+      <charseq START="205" END="225">the rest of the world</charseq>
+    </extent>
+    <head>
+      <charseq START="209" END="212">rest</charseq>
+    </head>
+  </entity_mention>
+</entity>
+<entity ID="VOA20001231.2000.3520-E8" TYPE="LOC" SUBTYPE="Celestial" CLASS="SPC">
+  <entity_mention ID="8-8" TYPE="NOM" LDCTYPE="NOM">
+    <extent>
+      <charseq START="217" END="225">the world</charseq>
+    </extent>
+    <head>
+      <charseq START="221" END="225">world</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="8-10" TYPE="NOM" LDCTYPE="NOM">
+    <extent>
+      <charseq START="257" END="265">the world</charseq>
+    </extent>
+    <head>
+      <charseq START="261" END="265">world</charseq>
+    </head>
+  </entity_mention>
+</entity>
+<entity ID="VOA20001231.2000.3520-E9" TYPE="PER" CLASS="SPC">
+  <entity_mention ID="9-9" TYPE="NOM" LDCTYPE="NOM">
+    <extent>
+      <charseq START="228" END="239">Many experts</charseq>
+    </extent>
+    <head>
+      <charseq START="233" END="239">experts</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="9-11" TYPE="NOM" LDCTYPE="NOM">
+    <extent>
+      <charseq START="369" END="381">These experts</charseq>
+    </extent>
+    <head>
+      <charseq START="375" END="381">experts</charseq>
+    </head>
+  </entity_mention>
+  <entity_mention ID="9-12" TYPE="PRO" LDCTYPE="PRO">
+    <extent>
+      <charseq START="503" END="506">They</charseq>
+    </extent>
+    <head>
+      <charseq START="503" END="506">They</charseq>
+    </head>
+  </entity_mention>
+</entity>
+<entity ID="VOA20001231.2000.3520-E10" TYPE="PER" CLASS="GEN">
+  <entity_mention ID="10-13" TYPE="PRO" LDCTYPE="HLS">
+    <extent>
+      <charseq START="572" END="647">those observing the start of
+2001 as a true dawn of the twenty-first century</charseq>
+    </extent>
+    <head>
+      <charseq START="572" END="576">those</charseq>
+    </head>
+  </entity_mention>
+</entity>
+<relation ID="VOA20001231.2000.3520-R1" TYPE="PHYS" SUBTYPE="Part-Whole">
+  <rel_entity_arg ENTITYID="VOA20001231.2000.3520-E7" ARGNUM="1" />
+  <rel_entity_arg ENTITYID="VOA20001231.2000.3520-E8" ARGNUM="2" />
+  <relation_mention ID="1-1" LDCLEXICALCONDITION="Preposition">
+    <ldc_extent>
+      <charseq START="205" END="225">the rest of the world</charseq>
+    </ldc_extent>
+    <rel_mention_arg ENTITYMENTIONID="7-7" ARGNUM="1">
+      <extent>
+        <charseq START="205" END="225">the rest of the world</charseq>
+      </extent>
+    </rel_mention_arg>
+    <rel_mention_arg ENTITYMENTIONID="8-8" ARGNUM="2">
+      <extent>
+        <charseq START="217" END="225">the world</charseq>
+      </extent>
+    </rel_mention_arg>
+  </relation_mention>
+</relation>
+<relation ID="VOA20001231.2000.3520-R2" TYPE="EMP-ORG" SUBTYPE="Employ-Executive">
+  <rel_entity_arg ENTITYID="VOA20001231.2000.3520-E2" ARGNUM="1" />
+  <rel_entity_arg ENTITYID="VOA20001231.2000.3520-E4" ARGNUM="2" />
+  <relation_mention ID="2-1" LDCLEXICALCONDITION="Possessive">
+    <ldc_extent>
+      <charseq START="776" END="786">his country</charseq>
+    </ldc_extent>
+    <rel_mention_arg ENTITYMENTIONID="2-18" ARGNUM="1">
+      <extent>
+        <charseq START="776" END="778">his</charseq>
+      </extent>
+    </rel_mention_arg>
+    <rel_mention_arg ENTITYMENTIONID="4-19" ARGNUM="2">
+      <extent>
+        <charseq START="776" END="786">his country</charseq>
+      </extent>
+    </rel_mention_arg>
+  </relation_mention>
+  <relation_mention ID="2-2" LDCLEXICALCONDITION="PreMod">
+    <ldc_extent>
+      <charseq START="65" END="76">Cuban leader</charseq>
+    </ldc_extent>
+    <rel_mention_arg ENTITYMENTIONID="4-4" ARGNUM="2">
+      <extent>
+        <charseq START="65" END="69">Cuban</charseq>
+      </extent>
+    </rel_mention_arg>
+    <rel_mention_arg ENTITYMENTIONID="2-3" ARGNUM="1">
+      <extent>
+        <charseq START="65" END="76">Cuban leader</charseq>
+      </extent>
+    </rel_mention_arg>
+  </relation_mention>
+</relation>
+<relation ID="VOA20001231.2000.3520-R3" TYPE="PHYS" SUBTYPE="Located">
+  <rel_entity_arg ENTITYID="VOA20001231.2000.3520-E1" ARGNUM="1" />
+  <rel_entity_arg ENTITYID="VOA20001231.2000.3520-E8" ARGNUM="2" />
+  <relation_mention ID="3-1" LDCLEXICALCONDITION="Preposition">
+    <ldc_extent>
+      <charseq START="249" END="265">most of the world</charseq>
+    </ldc_extent>
+    <rel_mention_arg ENTITYMENTIONID="1-2" ARGNUM="1">
+      <extent>
+        <charseq START="249" END="265">most of the world</charseq>
+      </extent>
+    </rel_mention_arg>
+    <rel_mention_arg ENTITYMENTIONID="8-10" ARGNUM="2">
+      <extent>
+        <charseq START="257" END="265">the world</charseq>
+      </extent>
+    </rel_mention_arg>
+  </relation_mention>
+</relation>
+</document>
+</source_file>

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/ace2004/bn/VOA20001231.2000.3520.sgm
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/ace2004/bn/VOA20001231.2000.3520.sgm
@@ -1,0 +1,23 @@
+<DOC>
+<DOCNO> VOA20001231.2000.3520 </DOCNO>
+<DOCTYPE SOURCE="broadcast news"> NEWS STORY </DOCTYPE>
+<DATE_TIME> 12/31/2000 20:58:40.20 </DATE_TIME>
+<BODY>
+<TEXT>
+Cuban leader Fidel Castro is setting up a lavish extravaganza on the
+island nation to welcome the new millennium, one year late for much
+of the rest of the world. Many experts contend most of the world was
+at least technically wrong by bringing in the new millennium with
+massive celebrations last year. These experts point out that the
+Gregorian calendar started in 1 AD and therefore, centuries'
+millennia start with a one, not a zero. They say this makes 2001 the
+first year of the third millennium. For those observing the start of
+2001 as a true dawn of the twenty-first century, the parties and
+fireworks are fewer and less elaborate than the 2000 celebrations.
+In Cuba though, where President Castro had his country sit out last
+year's revelry, they'll be making up for it as major festivities are
+set. 
+</TEXT>
+</BODY>
+<END_TIME> 12/31/2000 20:59:26.84 </END_TIME>
+</DOC>

--- a/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/ace2004/bn/apf.v4.0.1.dtd
+++ b/corpusreaders/src/test/resources/edu/illinois/cs/cogcomp/nlp/corpusreaders/ace2004/bn/apf.v4.0.1.dtd
@@ -1,0 +1,407 @@
+<!-- 
+			      A DTD for
+		     Reference Key Annotation of
+			   EDT Entities and
+			 RDC Relations in the
+			   ACE Evaluations
+
+			  John C. Henderson
+				MITRE
+                             2000-01-05
+
+v 1.1 Added versioning for semantic compatibility.
+      Added CHARSEQ in reponse to request from George Doddington.
+      Replaced ENTITY_NAME tag for encoding attribute with a general
+      ENTITY_ATTRIBUTES tag within which can be multiple attributes,
+      the only one of which we now have being NAME.
+
+v 1.2 Added extra attributes to SOURCE_FILE element, indicating source,
+      author and encoding.
+
+v 1.3 Added ROLE attribute under entity_mention and added GENERIC attribute
+      under entity_type.  Also added REFERENCE attribute to entity_mention
+      to indicate whether literal or intended.  Also changed ID attribute value
+      within document to CDATA (instead of ID)
+
+v 1.4 Added support for RDC relations, their attributes and mentions.
+      Also cleaned up and brought things up to date for EDT entities.
+      2002/03/24.  David Day.
+
+v 1.4.2 Removed rel_arg_role element, since this is now established within
+        SUBTYPE attribute on relation elements.  Added NA as valid value for
+        entity_mention REFERENCE attribute.
+        2002/05/01.  David Day.
+
+v 1.4.3 Changed all RELATION SUBTYPE values to use hyphens instead of underscore
+        characters in the case of multi-word phrases (e.g., "LOCATED-IN").
+        2002/05/28.  David Day.
+
+v 1.4.4 Modified RELATION element SUBTYPE attribute values: Added BASED-IN.
+        Removed NA from ENTITY_MENTION attribute values for ROLE and REFERENCE.
+        Instead of being REQUIRED these attributes are now IMPLIED (that is,
+        they are optional).
+
+v 2.0   SUBTYPE modifications:
+          Added:   CLIENT.
+          Changed: MEMBER-OF to MEMBER.
+          Removed: CONTAINED-IN.
+        VERSION modifications:
+          Changed: 1.4.4 to 2.0.
+        David; 2002-06-20.
+
+v 2.0.1 SUBTYPE modifications:
+		  Added: FROM
+				 BRANCH
+			     LOCATED-IN (LOCATED already existed; left both)
+		Robyn; 2002-06-28
+
+v 3.* became ALF (ACE LDC Format)
+
+v 4.0.0 LDC and BBN update: updated to version 4.0.0 to match new ALF dtd
+-->
+
+<!-- URI should be a unique identifier for the source file in question.
+     SOURCE is a more general indicator of the news source from whence
+       the source_file has been retrieved.  Likely values are CNN, APW,
+       NPR, etc.
+     TYPE indicates general class of signal (text, audio or image).
+     VERSION attribute is used to perform optionaly versioning by
+       matching against its value.
+     AUTHOR attribute value should indicate the organization and/or
+       person who produced the annotations contained in this file
+       (e.g., "Ramshaw/BBN", "Ferro/MITRE", etc.).
+     ENCODING indicates type-specific encoding standard being used
+       in source file, such as UTF-8 for text data, wav for speech
+       signals, etc.
+
+-->     
+
+<!ELEMENT source_file      (document)+>
+<!ATTLIST source_file
+                           URI      CDATA              #REQUIRED
+                           SOURCE   CDATA              #IMPLIED
+                           TYPE     (text|audio|image) #REQUIRED
+                           VERSION  (2.0|3.0|4.0)      #IMPLIED
+                           AUTHOR   CDATA              #IMPLIED
+                           ENCODING CDATA              #IMPLIED
+>
+
+
+<!-- By giving document ID the XML type ID (see entity), an implicit
+     promise is being made that there will be no duplicate document
+     IDs in a file.  CDATA will be used for now because IDREFs should
+     not be allowed to point to these DOCID ID's. --> 
+
+<!ELEMENT document         (entity*,relation*,event*)>
+<!ATTLIST document
+                           DOCID CDATA #REQUIRED
+>
+
+<!-- ********************************************** -->
+<!-- Entities, their attributes and their mentions. -->
+<!-- ********************************************** -->
+
+
+<!-- LDC: "entity_type" is now an attribute of entity 
+
+          SUBTYPE and CLASS added
+
+	  SUBTYPE is optional: Type "PER" does not have
+	  SUBTYPE, for example. 
+
+	  The following is a complete list of TYPE SUBTYPE pairs (as of 
+	  Nov. 19, 2003). 
+
+TYPE="PER" (no SUBTYPE)
+
+TYPE="ORG" SUBTYPE="Government"
+TYPE="ORG" SUBTYPE="Commercial"
+TYPE="ORG" SUBTYPE="Educational"
+TYPE="ORG" SUBTYPE="Non-Profit"
+TYPE="ORG" SUBTYPE="Other"
+
+TYPE="LOC" SUBTYPE="Address"
+TYPE="LOC" SUBTYPE="Boundary"
+TYPE="LOC" SUBTYPE="Celestial"
+TYPE="LOC" SUBTYPE="Water-Body"
+TYPE="LOC" SUBTYPE="Land-Region-Natural"
+TYPE="LOC" SUBTYPE="Region-Local"
+TYPE="LOC" SUBTYPE="Region-Subnational"
+TYPE="LOC" SUBTYPE="Region-National"
+TYPE="LOC" SUBTYPE="Region-International"
+
+TYPE="GPE" SUBTYPE="Continent"
+TYPE="GPE" SUBTYPE="Nation"
+TYPE="GPE" SUBTYPE="State-or-Province"
+TYPE="GPE" SUBTYPE="County-or-District"
+TYPE="GPE" SUBTYPE="Population-Center"
+TYPE="GPE" SUBTYPE="Other"
+
+TYPE="FAC" SUBTYPE="Building"
+TYPE="FAC" SUBTYPE="Subarea-Building"
+TYPE="FAC" SUBTYPE="Bounded-Area"
+TYPE="FAC" SUBTYPE="Conduit"
+TYPE="FAC" SUBTYPE="Path"
+TYPE="FAC" SUBTYPE="Barrier"
+TYPE="FAC" SUBTYPE="Plant"
+TYPE="FAC" SUBTYPE="Other"
+
+TYPE="VEH" SUBTYPE="Land"
+TYPE="VEH" SUBTYPE="Air"
+TYPE="VEH" SUBTYPE="Water"
+TYPE="VEH" SUBTYPE="Subarea-Vehicle"
+TYPE="VEH" SUBTYPE="Other"
+
+TYPE="WEA" SUBTYPE="Blunt"
+TYPE="WEA" SUBTYPE="Exploding"
+TYPE="WEA" SUBTYPE="Sharp"
+TYPE="WEA" SUBTYPE="Chemical"
+TYPE="WEA" SUBTYPE="Biological"
+TYPE="WEA" SUBTYPE="Shooting"
+TYPE="WEA" SUBTYPE="Projectile"
+TYPE="WEA" SUBTYPE="Nuclear"
+TYPE="WEA" SUBTYPE="Other"
+-->
+
+<!ELEMENT entity           (entity_mention+,entity_attributes*)>
+<!ATTLIST entity
+                         ID      CDATA                             #REQUIRED
+                         TYPE    (PER|ORG|LOC|GPE|FAC|VEH|WEA) #REQUIRED
+                         SUBTYPE (Government|Commercial|Educational|
+			          Non-Profit|Other|Address|Boundary|Celestial|
+				  Water-Body|Land-Region-Natural|Region-Local|
+				  Region-Subnational|Region-National|
+				  Region-International|Continent|Nation|
+				  State-or-Province|County-or-District|
+				  Population-Center|Building|
+				  Subarea-Building|Bounded-Area|Conduit|
+				  Path|Barrier|Plant|Land|Air|Water|
+				  Subarea-Vehicle|Blunt|Exploding|Sharp|
+				  Chemical|Biological|Shooting|Projectile|
+				  Nuclear)                         #IMPLIED
+                         CLASS   (NEG|SPC|GEN|USP)                 #REQUIRED
+
+>
+
+<!-- entity_mention -->
+
+<!ELEMENT entity_mention   (extent,head?)>
+<!ATTLIST entity_mention
+                           ID    CDATA                            #REQUIRED
+                           TYPE	(NAM|NOM|PRO|PRE)                 #REQUIRED
+                           LDCTYPE	(NAM|NOM|BAR|MWH|PRO|WHQ|PRE|HLS|MSC|
+                              PTV|CMC|APP|ARC|DE|PCN|PMM|EPM|EAP) #IMPLIED
+			   ROLE	(PER|ORG|LOC|GPE|FAC)             #IMPLIED
+			   REFERENCE (LITERAL|INTENDED)           #IMPLIED
+			   METONYMY_MENTION (TRUE|FALSE)	  #IMPLIED
+			   LDCATR   (TRUE|FALSE)                  #IMPLIED
+>
+
+<!-- There may be new attributes introduced in the future.  We incorporate
+     additional attributes underneath the single entity_attributes tag.
+     The name indexes directly into a portion of the signal, using one
+     of the four indexing types. -->
+
+<!ELEMENT entity_attributes (name*)>
+
+<!ELEMENT name             (bblist|charspan|charseq|timespan)>
+
+<!-- The extent is the maximal subset of the signal permitted in
+     judging correctness, and the head is the minimal subset. -->
+
+
+<!-- LDC: anchor added for events -->
+
+<!ELEMENT ldc_extent           (bblist|charspan|charseq|timespan)>
+<!ELEMENT extent           (bblist|charspan|charseq|timespan)>
+<!ELEMENT head             (bblist|charspan|charseq|timespan)>
+<!ELEMENT anchor           (bblist|charspan|charseq|timespan)>
+
+<!-- LDC: -->
+
+<!ELEMENT charspan         (#PCDATA)>
+<!ATTLIST charspan         START NMTOKEN  #REQUIRED
+                           END   NMTOKEN  #REQUIRED
+>
+
+<!ELEMENT charseq          (#PCDATA)>
+<!ATTLIST charseq          START NMTOKEN  #REQUIRED
+                           END   NMTOKEN  #REQUIRED
+>
+
+<!ELEMENT timespan         (#PCDATA)>
+<!ATTLIST timespan         START NMTOKEN  #REQUIRED
+                           END   NMTOKEN  #REQUIRED
+>
+
+<!-- A list of bounding boxes is needed to describe wrapped words in
+     an image. -->
+
+<!ELEMENT bblist           (pixelboundingbox)+>
+
+<!-- Alternate habits for describing bounding boxes.
+     Both can be supported because the tags wrap the elements. 
+     (x1,y1) will presumably be upper left point and 
+     (x2,y2) will be lower right point (suggested by English
+     reading order). --> 
+
+<!ELEMENT pixelboundingbox (x1,((x2,y1,y2)|(y1,x2,y2)))>
+
+<!-- A character SPAN (charspan) is a pair of indices that wraps
+     the signal being annotated in text.   This means that the first
+     index points to the imaginary gap *before* the first character
+     and the second index points to the imaginary gap *after* the
+     final character in the span.
+
+     A character SEQUENCE (charseq) is a pair of indices pointing to
+     the first and last character of the text being annotated.  This
+     means that the first index points to the first character of the
+     text being annotated (which is the same as pointing to the
+     imaginary gap *before* the first character), and the second index
+     points to the last character in the annotated text (the imaginary
+     gap *before* the last character in the annotated text). -->
+
+
+<!-- Perhaps these next elements are better suited to life as
+     attributes of the previous elements.  This is  an artform, after
+     all.  The other version would be *equivalent*, which is all
+     anyone should ask. -->
+
+<!ELEMENT x1               (#PCDATA)>
+<!ELEMENT x2               (#PCDATA)>
+<!ELEMENT y1               (#PCDATA)>
+<!ELEMENT y2               (#PCDATA)>
+
+<!-- *********************************************** -->
+<!-- RELATIONS, their attributes and their mentions. -->
+<!-- *********************************************** -->
+
+<!-- LDC: SUBTYPE is optional -->
+<!-- LDC: List of TYPE/SUBTYPE pairs (as of Nov. 19, 2003)
+
+TYPE="PHYS" SUBTYPE="Located"
+TYPE="PHYS" SUBTYPE="Near"
+TYPE="PHYS" SUBTYPE="Part-Whole"
+
+TYPE="PER-SOC" SUBTYPE="Business"
+TYPE="PER-SOC" SUBTYPE="Family"
+TYPE="PER-SOC" SUBTYPE="Other"
+
+TYPE="EMP-ORG" SUBTYPE="Employ-Executive"
+TYPE="EMP-ORG" SUBTYPE="Employ-Staff"
+TYPE="EMP-ORG" SUBTYPE="Employ-Undetermined"
+TYPE="EMP-ORG" SUBTYPE="Member-of-Group"
+TYPE="EMP-ORG" SUBTYPE="Subsidiary"
+TYPE="EMP-ORG" SUBTYPE="Partner"
+TYPE="EMP-ORG" SUBTYPE="Other"
+
+TYPE="ART" SUBTYPE="User-or-Owner"
+TYPE="ART" SUBTYPE="Inventor-or-Manufacturer"
+TYPE="ART" SUBTYPE="Other"
+
+TYPE="OTHER-AFF" SUBTYPE="Ethnic"
+TYPE="OTHER-AFF" SUBTYPE="Ideology"
+TYPE="OTHER-AFF" SUBTYPE="Other"
+
+TYPE="GPE-AFF" SUBTYPE="Citizen-or-Resident"
+TYPE="GPE-AFF" SUBTYPE="Based-In"
+TYPE="GPE-AFF" SUBTYPE="Other"
+
+TYPE="DISC" (no SUBTYPE)
+
+-->
+
+<!ELEMENT relation           (rel_entity_arg+, relation_mention*)>
+<!ATTLIST relation           
+                             ID       CDATA                     #REQUIRED
+                             TYPE     (PHYS|PER-SOC|EMP-ORG|ART|
+			               OTHER-AFF|GPE-AFF|DISC|
+				       METONYMY)                #REQUIRED
+                             SUBTYPE  (Located|Near|Part-Whole|Business|
+			               Family|Other|Employ-Executive|
+				       Employ-Staff|Employ-Undetermined|
+				       Member-of-Group|Subsidiary|Partner|
+				       User-or-Owner|
+				       Inventor-or-Manufacturer|Ethnic|
+				       Ideology|Citizen-or-Resident|
+				       Based-In)                 #IMPLIED
+>
+
+
+<!-- Note: rel_entity_arg elements carry all their information within
+     their arguments, so they be "empty" (without any further xml
+     or PCDATA content).  -->
+
+<!ELEMENT rel_entity_arg   (#PCDATA)>
+<!ATTLIST rel_entity_arg   ENTITYID CDATA  #REQUIRED
+                           ARGNUM   CDATA  #REQUIRED
+>
+
+<!ELEMENT relation_mentions   (relation_mention+)>
+
+<!ELEMENT relation_mention  (ldc_extent?,
+                             rel_mention_arg,
+                             rel_mention_arg+,
+                             rel_mention_time*)>
+<!ATTLIST relation_mention   
+                            ID                CDATA             #REQUIRED
+                            LDCLEXICALCONDITION  (Possessive|Preposition|
+                                               PreMod|Formulaic|Verbal|
+                                               Participial)     #IMPLIED
+>
+
+<!ELEMENT rel_mention_arg (extent?)>
+<!ATTLIST rel_mention_arg  
+                                     ENTITYMENTIONID CDATA  #REQUIRED	
+                                     ARGNUM          CDATA  #REQUIRED
+>
+
+<!-- The relation_mention_time element may be of two basic types: 
+     VALUE or ANCHOR.
+     If type VALUE,  the two attributes that it must specify are VAL and MOD.
+     If type ANCHOR, the two attributes that it must specify are VAL and DIR.
+     In each case the source string of the time information should be specified
+     via the source element.
+-->
+
+<!ELEMENT relation_mention_time  (source*)>
+<!ATTLIST relation_mention_time
+                                 TYPE  (VALUE|ANCHOR) #REQUIRED
+                                 VAL   CDATA          #REQUIRED
+                                 MOD   CDATA          #IMPLIED
+                                 DIR   CDATA          #IMPLIED
+>
+
+<!-- ****************************************************************** -->
+<!-- LDC: EVENTS, their attributes and their mentions.                  -->
+<!-- ****************************************************************** -->
+
+<!ELEMENT event             (event_mention+)>
+<!ATTLIST event 
+                            ID       CDATA                      #REQUIRED
+			    TYPE     (BRK|MAK|GIV|MOV|INT|OTH)  #REQUIRED
+			    MODALITY (Real|NotReal)             #REQUIRED
+>
+
+<!-- LDC: extent and anchor are required -->
+
+<!ELEMENT event_mention     (extent,anchor,event_mention_participant*)>
+<!ATTLIST event_mention   
+                            ID   CDATA      #REQUIRED
+                            TYPE (NOM|SEN)  #REQUIRED
+>
+
+<!ELEMENT event_mention_participant  (extent?,
+                                      event_mention_participant_relation_extent?)>
+<!ATTLIST event_mention_participant   
+                                     ENTITYID        CDATA   #REQUIRED
+                                     ENTITYMENTIONID CDATA   #REQUIRED
+                                     ROLE   (Agent|Object|Source|Target|
+	                                     Location|Time|
+			                     Modifier)       #REQUIRED
+	                             SOURCE (Event|Relation) #REQUIRED
+>
+
+<!ELEMENT event_mention_participant_relation_extent   (extent)>
+
+<!ELEMENT source            (extent)>


### PR DESCRIPTION
Partly addresses #160 

- Fixed the End Character offset for Entity's HEAD [Attribute]. Made the attribute one-after-the-last-character so that we can treat that as our regular character offset convention.
- Make the ACEReader parse documents lazily and not store the parsed documents in memory. [Helps with reducing memory footprint] : The `hasNext()` method parses one document and keeps a reference to it till the `next()` method is called to retrieve that document.

Pending issues:
- Adding attributes to TextAnnotation and have ACEReader populate document metadata. [Will send a separate PR to simplify review]
