### PR TITLE
Make AppVeyor configuration to only run JDK 8.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,7 @@ version: '{build}'
 skip_tags: true
 clone_depth: 10
 environment:
-  matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 branches:
   only:
     - master


### PR DESCRIPTION
Minor change to remove JDK 7.0 from configuration as we stopped supporting it.