### PR TITLE
[ACEReader] Add Attributes to TextAnnotation for Document metadata

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/constants/DocumentMetadata.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/constants/DocumentMetadata.java
@@ -1,0 +1,14 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.core.constants;
+
+public class DocumentMetadata {
+    public static final String DocumentID = "documentID";
+    public static final String DocumentCreationTime = "documentCreationTime";
+    public static final String HeadLine = "headLine";
+}

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/HasAttributes.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/HasAttributes.java
@@ -1,0 +1,25 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.core.datastructures;
+
+import java.util.Set;
+
+/**
+ * Interface for common methods when supporting attributes.
+ */
+public interface HasAttributes {
+    void setAttribute(String key, String value);
+
+    String getAttribute(String key);
+
+    Set<String> getAttributeKeys();
+
+    boolean hasAttribute(String key);
+
+    void removeAllAttributes();
+}

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/HasAttributes.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/HasAttributes.java
@@ -13,7 +13,7 @@ import java.util.Set;
  * Interface for common methods when supporting attributes.
  */
 public interface HasAttributes {
-    void setAttribute(String key, String value);
+    void addAttribute(String key, String value);
 
     String getAttribute(String key);
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
@@ -7,6 +7,7 @@
  */
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
+import edu.illinois.cs.cogcomp.core.datastructures.HasAttributes;
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 
 import java.io.Serializable;
@@ -20,7 +21,7 @@ import java.util.*;
  *
  * @author Vivek Srikumar
  */
-public class Constituent implements Serializable {
+public class Constituent implements Serializable, HasAttributes {
 
     private static final long serialVersionUID = -4241917156773356414L;
 
@@ -154,10 +155,9 @@ public class Constituent implements Serializable {
         return endCharOffset - 1;
     }
 
+    @Deprecated
     public void addAttribute(String key, String value) {
-        if (attributes == null)
-            attributes = new HashMap<>();
-        attributes.put(key, value);
+        this.setAttribute(key, value);
     }
 
     public boolean doesConstituentCover(int tokenId) {
@@ -244,6 +244,12 @@ public class Constituent implements Serializable {
                 && this.constituentScore == that.constituentScore
                 && this.getViewName().equals(that.getViewName());
 
+    }
+
+    public void setAttribute(String key, String value) {
+        if (attributes == null)
+            attributes = new HashMap<>();
+        attributes.put(key, value);
     }
 
     public String getAttribute(String key) {

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Constituent.java
@@ -155,9 +155,10 @@ public class Constituent implements Serializable, HasAttributes {
         return endCharOffset - 1;
     }
 
-    @Deprecated
     public void addAttribute(String key, String value) {
-        this.setAttribute(key, value);
+        if (attributes == null)
+            attributes = new HashMap<>();
+        attributes.put(key, value);
     }
 
     public boolean doesConstituentCover(int tokenId) {
@@ -244,12 +245,6 @@ public class Constituent implements Serializable, HasAttributes {
                 && this.constituentScore == that.constituentScore
                 && this.getViewName().equals(that.getViewName());
 
-    }
-
-    public void setAttribute(String key, String value) {
-        if (attributes == null)
-            attributes = new HashMap<>();
-        attributes.put(key, value);
     }
 
     public String getAttribute(String key) {

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Relation.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Relation.java
@@ -7,6 +7,8 @@
  */
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
+import edu.illinois.cs.cogcomp.core.datastructures.HasAttributes;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -18,7 +20,7 @@ import java.util.Set;
  *         <p>
  *         Aug 4, 2009
  */
-public class Relation implements Serializable {
+public class Relation implements Serializable, HasAttributes {
 
     private static final long serialVersionUID = -1005341815252250162L;
     protected final int relationName;
@@ -121,6 +123,10 @@ public class Relation implements Serializable {
             return new HashSet<>();
         else
             return this.attributes.keySet();
+    }
+
+    public boolean hasAttribute(String key) {
+        return this.attributes != null && this.attributes.containsKey(key);
     }
 
     /**

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Relation.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/Relation.java
@@ -101,7 +101,7 @@ public class Relation implements Serializable, HasAttributes {
     }
 
 
-    public void setAttribute( String key, String value )
+    public void addAttribute(String key, String value )
     {
         if ( null == attributes )
             attributes = new HashMap<>();

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotation.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotation.java
@@ -395,7 +395,7 @@ public class TextAnnotation extends AbstractTextAnnotation implements Serializab
         return list;
     }
 
-    public void setAttribute(String key, String value)
+    public void addAttribute(String key, String value)
     {
         if (attributes == null)
             attributes = new HashMap<>();

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotation.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotation.java
@@ -9,6 +9,7 @@ package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
 import edu.illinois.cs.cogcomp.annotation.Annotator;
 import edu.illinois.cs.cogcomp.annotation.AnnotatorException;
+import edu.illinois.cs.cogcomp.core.datastructures.HasAttributes;
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.nlp.utilities.SentenceUtils;
@@ -19,7 +20,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.Serializable;
 import java.util.*;
-import java.util.logging.Logger;
 
 /**
  * This class contains all annotation for a single piece of text (which could contain more than one
@@ -28,7 +28,7 @@ import java.util.logging.Logger;
  *
  * @author Vivek Srikumar
  */
-public class TextAnnotation extends AbstractTextAnnotation implements Serializable, Cloneable {
+public class TextAnnotation extends AbstractTextAnnotation implements Serializable, Cloneable, HasAttributes {
 
     private static final long serialVersionUID = -1308407121595094945L;
 
@@ -57,6 +57,11 @@ public class TextAnnotation extends AbstractTextAnnotation implements Serializab
     protected int[] characterOffsetsToTokens = null;
 
     protected TIntObjectMap<ArrayList<IntPair>> allSpans = null;
+
+    /**
+     * Mop containing attributes/metadata information related to TextAnnotation.
+     */
+    protected Map<String, String> attributes;
 
     /**
      * A symbol table.
@@ -174,9 +179,12 @@ public class TextAnnotation extends AbstractTextAnnotation implements Serializab
 
     @Override
     public int hashCode() {
-        return this.corpusId.hashCode() * 13 + this.id.hashCode() * 17 + this.text.hashCode() * 19
+        int hashCode = this.corpusId.hashCode() * 13 + this.id.hashCode() * 17 + this.text.hashCode() * 19
                 + (tokens == null ? 0 : Arrays.hashCode(tokens) * 43)
                 + (this.sentences().hashCode() * 31);
+        hashCode += (this.attributes == null ? 0 : this.attributes.hashCode() * 13);
+
+        return hashCode;
     }
 
     @Override
@@ -191,6 +199,14 @@ public class TextAnnotation extends AbstractTextAnnotation implements Serializab
 
         if (!this.corpusId.equals(that.corpusId) || !this.id.equals(that.id)
                 || !this.text.equals(that.text))
+            return false;
+
+        if (this.attributes == null && that.attributes != null)
+            return false;
+        if (this.attributes != null && that.attributes == null)
+            return false;
+
+        if (this.attributes != null && !this.attributes.equals(that.attributes))
             return false;
 
         if (this.tokens == null && that.tokens == null)
@@ -229,8 +245,6 @@ public class TextAnnotation extends AbstractTextAnnotation implements Serializab
         }
         return sentences;
     }
-
-
 
     /**
      * Get the position of token that corresponds to the character offset that is passed as a
@@ -379,5 +393,29 @@ public class TextAnnotation extends AbstractTextAnnotation implements Serializab
         // return newList;
 
         return list;
+    }
+
+    public void setAttribute(String key, String value)
+    {
+        if (attributes == null)
+            attributes = new HashMap<>();
+
+        attributes.put(key, value);
+    }
+
+    public String getAttribute(String key) {
+        return this.attributes == null ? null : this.attributes.getOrDefault(key, null);
+    }
+
+    public Set<String> getAttributeKeys() {
+        return this.attributes == null ? Collections.emptySet() : this.attributes.keySet();
+    }
+
+    public boolean hasAttribute(String key) {
+        return this.attributes == null ? false : this.attributes.containsKey(key);
+    }
+
+    public void removeAllAttributes() {
+        this.attributes = null;
     }
 }

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestAttributes.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestAttributes.java
@@ -1,0 +1,56 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
+package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
+
+import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
+import edu.illinois.cs.cogcomp.core.utilities.DummyTextAnnotationGenerator;
+import org.junit.Before;
+import org.junit.Test;
+
+public class TestAttributes {
+    private TextAnnotation ta;
+
+    @Before
+    public void setUp() {
+        this.ta = DummyTextAnnotationGenerator.generateAnnotatedTextAnnotation(false, 3);
+    }
+
+    @Test
+    public void testAttributes() throws CloneNotSupportedException {
+        TextAnnotation taCopy = (TextAnnotation) ta.clone();
+
+        assert ta.equals(taCopy);
+        assert ta.hashCode() == taCopy.hashCode();
+
+        // Adding same attribute to both TextAnnotations
+        ta.setAttribute("Test", "TestValue");
+        taCopy.setAttribute("Test", "TestValue");
+
+        assert ta.equals(taCopy);
+        assert ta.hashCode() == taCopy.hashCode();
+
+        ta.setAttribute("Test2", "TestValue");
+
+        assert !ta.equals(taCopy);
+        assert ta.hashCode() != taCopy.hashCode();
+
+        assert ta.hasAttribute("Test2");
+        assert ta.getAttribute("Test2").equals("TestValue");
+    }
+
+    @Test
+    public void testAttributeRemove() throws CloneNotSupportedException {
+        TextAnnotation taCopy = (TextAnnotation) ta.clone();
+
+        taCopy.setAttribute("Test", "TestValue");
+        taCopy.removeAllAttributes();
+
+        assert ta.equals(taCopy);
+        assert ta.hashCode() == taCopy.hashCode();
+    }
+}

--- a/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestAttributes.java
+++ b/core-utilities/src/test/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TestAttributes.java
@@ -7,7 +7,6 @@
  */
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
-import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.utilities.DummyTextAnnotationGenerator;
 import org.junit.Before;
 import org.junit.Test;
@@ -28,13 +27,13 @@ public class TestAttributes {
         assert ta.hashCode() == taCopy.hashCode();
 
         // Adding same attribute to both TextAnnotations
-        ta.setAttribute("Test", "TestValue");
-        taCopy.setAttribute("Test", "TestValue");
+        ta.addAttribute("Test", "TestValue");
+        taCopy.addAttribute("Test", "TestValue");
 
         assert ta.equals(taCopy);
         assert ta.hashCode() == taCopy.hashCode();
 
-        ta.setAttribute("Test2", "TestValue");
+        ta.addAttribute("Test2", "TestValue");
 
         assert !ta.equals(taCopy);
         assert ta.hashCode() != taCopy.hashCode();
@@ -47,7 +46,7 @@ public class TestAttributes {
     public void testAttributeRemove() throws CloneNotSupportedException {
         TextAnnotation taCopy = (TextAnnotation) ta.clone();
 
-        taCopy.setAttribute("Test", "TestValue");
+        taCopy.addAttribute("Test", "TestValue");
         taCopy.removeAllAttributes();
 
         assert ta.equals(taCopy);

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
@@ -198,6 +198,13 @@ public class ACEReader extends TextAnnotationReader {
                         textId,
                         doc.contentRemovingTags);
 
+        // Add metadata attributes to the generated Text Annotation.
+        if (doc.metadata != null) {
+            for (String metadataKey : doc.metadata.keySet()) {
+                ta.setAttribute(metadataKey, doc.metadata.get(metadataKey));
+            }
+        }
+
         File file = new File( fileName );
         this.addEntityViews(ta, doc.aceAnnotation, file);
         this.addEntityRelations(ta, doc.aceAnnotation, file);

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
@@ -201,7 +201,10 @@ public class ACEReader extends TextAnnotationReader {
         // Add metadata attributes to the generated Text Annotation.
         if (doc.metadata != null) {
             for (String metadataKey : doc.metadata.keySet()) {
-                ta.setAttribute(metadataKey, doc.metadata.get(metadataKey));
+                String value = doc.metadata.get(metadataKey);
+                if (!value.isEmpty()) {
+                    ta.addAttribute(metadataKey, value);
+                }
             }
         }
 
@@ -410,22 +413,22 @@ public class ACEReader extends TextAnnotationReader {
                 Relation entityRelation = new Relation(relation.type, firstArgument, secondArgument, 1.0f);
 
                 // Add attributes to each of the relation.
-                entityRelation.setAttribute(RelationIDAttribute, relation.id);
-                entityRelation.setAttribute(RelationTypeAttribute, relation.type);
+                entityRelation.addAttribute(RelationIDAttribute, relation.id);
+                entityRelation.addAttribute(RelationTypeAttribute, relation.type);
 
                 String relationSubType = (relation.subtype != null) ? relation.subtype : relation.type;
-                entityRelation.setAttribute(RelationSubtypeAttribute, relationSubType);
+                entityRelation.addAttribute(RelationSubtypeAttribute, relationSubType);
 
                 if (relation.tense != null) {
-                    entityRelation.setAttribute(RelationTenseAttribute, relation.tense);
+                    entityRelation.addAttribute(RelationTenseAttribute, relation.tense);
                 }
 
                 if (relation.modality != null) {
-                    entityRelation.setAttribute(RelationModalityAttribute, relation.modality);
+                    entityRelation.addAttribute(RelationModalityAttribute, relation.modality);
                 }
 
-                entityRelation.setAttribute(RelationMentionIDAttribute, relationMention.id);
-                entityRelation.setAttribute(RelationMentionLexicalConditionAttribute, relationMention.lexicalCondition);
+                entityRelation.addAttribute(RelationMentionIDAttribute, relationMention.id);
+                entityRelation.addAttribute(RelationMentionLexicalConditionAttribute, relationMention.lexicalCondition);
 
                 // Add relation to the entity view.
                 entityView.addRelation(entityRelation);

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/annotationStructure/ACEDocument.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/annotationStructure/ACEDocument.java
@@ -12,6 +12,7 @@ import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.Paragraph;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Map;
 
 public class ACEDocument implements Serializable {
 
@@ -23,6 +24,7 @@ public class ACEDocument implements Serializable {
 
     public List<String> originalLines;
 
-    public List<Pair<String, Paragraph>> paragraphs;
+    public Map<String, String> metadata;
 
+    public List<Pair<String, Paragraph>> paragraphs;
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_BC_Reader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_BC_Reader.java
@@ -7,11 +7,14 @@
  */
 package edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader;
 
+import edu.illinois.cs.cogcomp.core.constants.DocumentMetadata;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.Paragraph;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,8 +22,10 @@ final class ACE_BC_Reader {
 
     static boolean isDebug = false;
 
-    public static List<Pair<String, Paragraph>> parse(String content, String contentRemovingTags) {
-        List<Pair<String, Paragraph>> paragraphs = new ArrayList<Pair<String, Paragraph>>();
+    public static Pair<List<Pair<String, Paragraph>>, Map<String, String>> parse(String content,
+                                                                                 String contentRemovingTags) {
+        List<Pair<String, Paragraph>> paragraphs = new ArrayList<>();
+        Map<String, String> metadata = new HashMap<>();
 
         Pattern pattern = null;
         Matcher matcher = null;
@@ -35,30 +40,21 @@ final class ACE_BC_Reader {
         while (matcher.find()) {
             docID = (matcher.group(1)).trim();
         }
-        int index1 = content.indexOf(docID);
-        Paragraph para1 = new Paragraph(index1, docID);
-        Pair<String, Paragraph> pair1 = new Pair<String, Paragraph>("docID", para1);
-        paragraphs.add(pair1);
+        metadata.put(DocumentMetadata.DocumentID, docID);
 
         pattern = Pattern.compile("<DATETIME>(.*?)</DATETIME>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             dateTime = (matcher.group(1)).trim();
         }
-        int index2 = content.indexOf(dateTime);
-        Paragraph para2 = new Paragraph(index2, dateTime);
-        Pair<String, Paragraph> pair2 = new Pair<String, Paragraph>("dateTime", para2);
-        paragraphs.add(pair2);
+        metadata.put(DocumentMetadata.DocumentCreationTime, dateTime);
 
         pattern = Pattern.compile("<HEADLINE>(.*?)</HEADLINE>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             headLine = (matcher.group(1)).trim();
         }
-        int index3 = content.indexOf(headLine);
-        Paragraph para3 = new Paragraph(index3, headLine);
-        Pair<String, Paragraph> pair3 = new Pair<String, Paragraph>("headLine", para3);
-        paragraphs.add(pair3);
+        metadata.put(DocumentMetadata.HeadLine, headLine);
 
         pattern = Pattern.compile("<TURN>(.*?)</TURN>");
         matcher = pattern.matcher(content);
@@ -96,7 +92,6 @@ final class ACE_BC_Reader {
             }
         }
 
-        return paragraphs;
+        return new Pair<>(paragraphs, metadata);
     }
-
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_BN_Reader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_BN_Reader.java
@@ -7,11 +7,14 @@
  */
 package edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader;
 
+import edu.illinois.cs.cogcomp.core.constants.DocumentMetadata;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.Paragraph;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,9 +22,11 @@ final class ACE_BN_Reader {
 
     static boolean isDebug = false;
 
-    public static List<Pair<String, Paragraph>> parse(String content, String contentRemovingTags,
-            boolean is2004) {
-        List<Pair<String, Paragraph>> paragraphs = new ArrayList<Pair<String, Paragraph>>();
+    public static Pair<List<Pair<String, Paragraph>>, Map<String, String>> parse(String content,
+                                                                                 String contentRemovingTags,
+                                                                                 boolean is2004) {
+        List<Pair<String, Paragraph>> paragraphs = new ArrayList<>();
+        Map<String, String> metadata = new HashMap<>();
 
         Pattern pattern = null;
         Matcher matcher = null;
@@ -32,28 +37,22 @@ final class ACE_BN_Reader {
         String text = "";
 
         pattern =
-                is2004 ? Pattern.compile("<DOCNO>(.*?)</DOCNO>") : Pattern
-                        .compile("<DOCID>(.*?)</DOCID>");
+                is2004 ? Pattern.compile("<DOCNO>(.*?)</DOCNO>") :
+                        Pattern.compile("<DOCID>(.*?)</DOCID>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             docID = (matcher.group(1)).trim();
         }
-        int index1 = content.indexOf(docID);
-        Paragraph para1 = new Paragraph(index1, docID);
-        Pair<String, Paragraph> pair1 = new Pair<String, Paragraph>("docID", para1);
-        paragraphs.add(pair1);
+        metadata.put(DocumentMetadata.DocumentID, docID);
 
         pattern =
-                is2004 ? Pattern.compile("<DATE_TIME>(.*?)</DATE_TIME>") : Pattern
-                        .compile("<DATETIME>(.*?)</DATETIME>");
+                is2004 ? Pattern.compile("<DATE_TIME>(.*?)</DATE_TIME>") :
+                        Pattern.compile("<DATETIME>(.*?)</DATETIME>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             dateTime = (matcher.group(1)).trim();
         }
-        int index2 = content.indexOf(dateTime);
-        Paragraph para2 = new Paragraph(index2, dateTime);
-        Pair<String, Paragraph> pair2 = new Pair<String, Paragraph>("dateTime", para2);
-        paragraphs.add(pair2);
+        metadata.put(DocumentMetadata.DocumentCreationTime, dateTime);
 
         if (is2004) {
             pattern =
@@ -109,17 +108,6 @@ final class ACE_BN_Reader {
             }
         }
 
-        // if (isDebug) {
-        // for (int i = 0; i < paragraphs.size(); ++i) {
-        // System.out.println(paragraphs.get(i).getFirst() + "--> " +
-        // paragraphs.get(i).getSecond().content);
-        // System.out.println(content.substring(paragraphs.get(i).getSecond().offset,
-        // paragraphs.get(i).getSecond().offset + paragraphs.get(i).getSecond().content.length()));
-        // System.out.println();
-        // }
-        // }
-
-        return paragraphs;
+        return new Pair<>(paragraphs, metadata);
     }
-
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_CTS_Reader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_CTS_Reader.java
@@ -7,11 +7,14 @@
  */
 package edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader;
 
+import edu.illinois.cs.cogcomp.core.constants.DocumentMetadata;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.Paragraph;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,8 +22,10 @@ final class ACE_CTS_Reader {
 
     static boolean isDebug = false;
 
-    public static List<Pair<String, Paragraph>> parse(String content, String contentRemovingTags) {
+    public static Pair<List<Pair<String, Paragraph>>, Map<String, String>> parse(String content,
+                                                                                 String contentRemovingTags) {
         List<Pair<String, Paragraph>> paragraphs = new ArrayList<>();
+        Map<String, String> metadata = new HashMap<>();
 
         Pattern pattern = null;
         Matcher matcher = null;
@@ -35,20 +40,14 @@ final class ACE_CTS_Reader {
         while (matcher.find()) {
             docID = (matcher.group(1)).trim();
         }
-        int index1 = content.indexOf(docID);
-        Paragraph para1 = new Paragraph(index1, docID);
-        Pair<String, Paragraph> pair1 = new Pair<String, Paragraph>("docID", para1);
-        paragraphs.add(pair1);
+        metadata.put(DocumentMetadata.DocumentID, docID);
 
         pattern = Pattern.compile("<DATETIME>(.*?)</DATETIME>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             dateTime = (matcher.group(1)).trim();
         }
-        int index2 = content.indexOf(dateTime);
-        Paragraph para2 = new Paragraph(index2, dateTime);
-        Pair<String, Paragraph> pair2 = new Pair<String, Paragraph>("dateTime", para2);
-        paragraphs.add(pair2);
+        metadata.put(DocumentMetadata.DocumentCreationTime, dateTime);
 
         pattern = Pattern.compile("<TURN>(.*?)</TURN>");
         matcher = pattern.matcher(content);
@@ -86,17 +85,6 @@ final class ACE_CTS_Reader {
             }
         }
 
-        // if (isDebug) {
-        // for (int i = 0; i < paragraphs.size(); ++i) {
-        // System.out.println(paragraphs.get(i).getFirst() + "--> " +
-        // paragraphs.get(i).getSecond().content);
-        // System.out.println(content.substring(paragraphs.get(i).getSecond().offset,
-        // paragraphs.get(i).getSecond().offset + paragraphs.get(i).getSecond().content.length()));
-        // System.out.println();
-        // }
-        // }
-
-        return paragraphs;
+        return new Pair<>(paragraphs, metadata);
     }
-
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_NW_Reader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_NW_Reader.java
@@ -7,11 +7,14 @@
  */
 package edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader;
 
+import edu.illinois.cs.cogcomp.core.constants.DocumentMetadata;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.Paragraph;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,8 +22,10 @@ final class ACE_NW_Reader {
 
     static boolean isDebug = false;
 
-    public static List<Pair<String, Paragraph>> parse(String content, String contentRemovingTags) {
-        List<Pair<String, Paragraph>> paragraphs = new ArrayList<Pair<String, Paragraph>>();
+    public static Pair<List<Pair<String, Paragraph>>, Map<String, String>> parse(String content,
+                                                                                 String contentRemovingTags) {
+        List<Pair<String, Paragraph>> paragraphs = new ArrayList<>();
+        Map<String, String> metadata = new HashMap<>();
 
         Pattern pattern = null;
         Matcher matcher = null;
@@ -35,30 +40,21 @@ final class ACE_NW_Reader {
         while (matcher.find()) {
             docID = (matcher.group(1)).trim();
         }
-        int index1 = content.indexOf(docID);
-        Paragraph para1 = new Paragraph(index1, docID);
-        Pair<String, Paragraph> pair1 = new Pair<String, Paragraph>("docID", para1);
-        paragraphs.add(pair1);
+        metadata.put(DocumentMetadata.DocumentID, docID);
 
         pattern = Pattern.compile("<DATETIME>(.*?)</DATETIME>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             dateTime = (matcher.group(1)).trim();
         }
-        int index2 = content.indexOf(dateTime);
-        Paragraph para2 = new Paragraph(index2, dateTime);
-        Pair<String, Paragraph> pair2 = new Pair<String, Paragraph>("dateTime", para2);
-        paragraphs.add(pair2);
+        metadata.put(DocumentMetadata.DocumentCreationTime, dateTime);
 
         pattern = Pattern.compile("<HEADLINE>(.*?)</HEADLINE>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             headLine = (matcher.group(1)).trim();
         }
-        int index3 = content.indexOf(headLine);
-        Paragraph para3 = new Paragraph(index3, headLine);
-        Pair<String, Paragraph> pair3 = new Pair<String, Paragraph>("headLine", para3);
-        paragraphs.add(pair3);
+        metadata.put(DocumentMetadata.HeadLine, headLine);
 
         pattern = Pattern.compile("<TEXT>(.*?)</TEXT>");
         matcher = pattern.matcher(content);
@@ -94,17 +90,6 @@ final class ACE_NW_Reader {
             }
         }
 
-        // if (isDebug) {
-        // for (int i = 0; i < paragraphs.size(); ++i) {
-        // System.out.println(paragraphs.get(i).getFirst() + "--> " +
-        // paragraphs.get(i).getSecond().content);
-        // System.out.println(content.substring(paragraphs.get(i).getSecond().offset,
-        // paragraphs.get(i).getSecond().offset + paragraphs.get(i).getSecond().content.length()));
-        // System.out.println();
-        // }
-        // }
-
-        return paragraphs;
+        return new Pair<>(paragraphs, metadata);
     }
-
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_UN_Reader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_UN_Reader.java
@@ -7,11 +7,14 @@
  */
 package edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader;
 
+import edu.illinois.cs.cogcomp.core.constants.DocumentMetadata;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.Paragraph;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,8 +22,10 @@ final class ACE_UN_Reader {
 
     static boolean isDebug = false;
 
-    public static List<Pair<String, Paragraph>> parse(String content, String contentRemovingTags) {
-        List<Pair<String, Paragraph>> paragraphs = new ArrayList<Pair<String, Paragraph>>();
+    public static Pair<List<Pair<String, Paragraph>>, Map<String, String>> parse(String content,
+                                                                                 String contentRemovingTags) {
+        List<Pair<String, Paragraph>> paragraphs = new ArrayList<>();
+        Map<String, String> metadata = new HashMap<>();
 
         Pattern pattern = null;
         Matcher matcher = null;
@@ -35,30 +40,21 @@ final class ACE_UN_Reader {
         while (matcher.find()) {
             docID = (matcher.group(1)).trim();
         }
-        int index1 = content.indexOf(docID);
-        Paragraph para1 = new Paragraph(index1, docID);
-        Pair<String, Paragraph> pair1 = new Pair<String, Paragraph>("docID", para1);
-        paragraphs.add(pair1);
+        metadata.put(DocumentMetadata.DocumentID, docID);
 
         pattern = Pattern.compile("<DATETIME>(.*?)</DATETIME>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             dateTime = (matcher.group(1)).trim();
         }
-        int index2 = content.indexOf(dateTime);
-        Paragraph para2 = new Paragraph(index2, dateTime);
-        Pair<String, Paragraph> pair2 = new Pair<String, Paragraph>("dateTime", para2);
-        paragraphs.add(pair2);
+        metadata.put(DocumentMetadata.DocumentCreationTime, dateTime);
 
         pattern = Pattern.compile("<HEADLINE>(.*?)</HEADLINE>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             headLine = (matcher.group(1)).trim();
         }
-        int index3 = content.indexOf(headLine);
-        Paragraph para3 = new Paragraph(index3, headLine);
-        Pair<String, Paragraph> pair3 = new Pair<String, Paragraph>("headLine", para3);
-        paragraphs.add(pair3);
+        metadata.put(DocumentMetadata.HeadLine, headLine);
 
         pattern = Pattern.compile("<POST>(.*?)</POST>");
         matcher = pattern.matcher(content);
@@ -199,17 +195,6 @@ final class ACE_UN_Reader {
             }
         }
 
-        // if (isDebug) {
-        // for (int i = 0; i < paragraphs.size(); ++i) {
-        // System.out.println(paragraphs.get(i).getFirst() + "--> " +
-        // paragraphs.get(i).getSecond().content);
-        // System.out.println(content.substring(paragraphs.get(i).getSecond().offset,
-        // paragraphs.get(i).getSecond().offset + paragraphs.get(i).getSecond().content.length()));
-        // System.out.println();
-        // }
-        // }
-
-        return paragraphs;
+        return new Pair<>(paragraphs, metadata);
     }
-
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_WL_Reader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/ACE_WL_Reader.java
@@ -7,11 +7,14 @@
  */
 package edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader;
 
+import edu.illinois.cs.cogcomp.core.constants.DocumentMetadata;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.Paragraph;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -19,8 +22,10 @@ final class ACE_WL_Reader {
 
     static boolean isDebug = false;
 
-    public static List<Pair<String, Paragraph>> parse(String content, String contentRemovingTags) {
-        List<Pair<String, Paragraph>> paragraphs = new ArrayList<Pair<String, Paragraph>>();
+    public static Pair<List<Pair<String, Paragraph>>, Map<String, String>> parse(String content,
+                                                                                 String contentRemovingTags) {
+        List<Pair<String, Paragraph>> paragraphs = new ArrayList<>();
+        Map<String, String> metadata = new HashMap<>();
 
         Pattern pattern = null;
         Matcher matcher = null;
@@ -35,30 +40,21 @@ final class ACE_WL_Reader {
         while (matcher.find()) {
             docID = (matcher.group(1)).trim();
         }
-        int index1 = content.indexOf(docID);
-        Paragraph para1 = new Paragraph(index1, docID);
-        Pair<String, Paragraph> pair1 = new Pair<String, Paragraph>("docID", para1);
-        paragraphs.add(pair1);
+        metadata.put(DocumentMetadata.DocumentCreationTime, docID);
 
         pattern = Pattern.compile("<DATETIME>(.*?)</DATETIME>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             dateTime = (matcher.group(1)).trim();
         }
-        int index2 = content.indexOf(dateTime);
-        Paragraph para2 = new Paragraph(index2, dateTime);
-        Pair<String, Paragraph> pair2 = new Pair<String, Paragraph>("dateTime", para2);
-        paragraphs.add(pair2);
+        metadata.put(DocumentMetadata.DocumentCreationTime, dateTime);
 
         pattern = Pattern.compile("<HEADLINE>(.*?)</HEADLINE>");
         matcher = pattern.matcher(content);
         while (matcher.find()) {
             headLine = (matcher.group(1)).trim();
         }
-        int index3 = content.indexOf(headLine);
-        Paragraph para3 = new Paragraph(index3, headLine);
-        Pair<String, Paragraph> pair3 = new Pair<String, Paragraph>("headLine", para3);
-        paragraphs.add(pair3);
+        metadata.put(DocumentMetadata.HeadLine, headLine);
 
         pattern = Pattern.compile("<POST>(.*?)</POST>");
         matcher = pattern.matcher(content);
@@ -108,7 +104,6 @@ final class ACE_WL_Reader {
             }
         }
 
-        return paragraphs;
+        return new Pair<>(paragraphs, metadata);
     }
-
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/AceFileProcessor.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/aceReader/documentReader/AceFileProcessor.java
@@ -125,19 +125,19 @@ public class AceFileProcessor {
 
         String contentRemovingTags = textContentWithoutTagsBuilder.toString();
 
-        List<Pair<String, Paragraph>> paraList = null;
+        Pair<List<Pair<String, Paragraph>>, Map<String, String>> parsedResult = null;
         if (subFolderEntry.getAbsolutePath().endsWith("bc")) {
-            paraList = ACE_BC_Reader.parse(contentWithoutEnter, contentRemovingTags);
+            parsedResult = ACE_BC_Reader.parse(contentWithoutEnter, contentRemovingTags);
         } else if (subFolderEntry.getAbsolutePath().endsWith("bn")) {
-            paraList = ACE_BN_Reader.parse(contentWithoutEnter, contentRemovingTags, is2004mode);
+            parsedResult = ACE_BN_Reader.parse(contentWithoutEnter, contentRemovingTags, is2004mode);
         } else if (subFolderEntry.getAbsolutePath().endsWith("cts")) {
-            paraList = ACE_CTS_Reader.parse(contentWithoutEnter, contentRemovingTags);
+            parsedResult = ACE_CTS_Reader.parse(contentWithoutEnter, contentRemovingTags);
         } else if (subFolderEntry.getAbsolutePath().endsWith("nw")) {
-            paraList = ACE_NW_Reader.parse(contentWithoutEnter, contentRemovingTags);
+            parsedResult = ACE_NW_Reader.parse(contentWithoutEnter, contentRemovingTags);
         } else if (subFolderEntry.getAbsolutePath().endsWith("un")) {
-            paraList = ACE_UN_Reader.parse(contentWithoutEnter, contentRemovingTags);
+            parsedResult = ACE_UN_Reader.parse(contentWithoutEnter, contentRemovingTags);
         } else if (subFolderEntry.getAbsolutePath().endsWith("wl")) {
-            paraList = ACE_WL_Reader.parse(contentWithoutEnter, contentRemovingTags);
+            parsedResult = ACE_WL_Reader.parse(contentWithoutEnter, contentRemovingTags);
         }
 
         // Normalize the text content
@@ -147,7 +147,11 @@ public class AceFileProcessor {
         aceDoc.orginalContent = content;
         aceDoc.contentRemovingTags = cleanedTextContent;
         aceDoc.originalLines = lines;
-        aceDoc.paragraphs = paraList;
+
+        if (parsedResult != null) {
+            aceDoc.paragraphs = parsedResult.getFirst();
+            aceDoc.metadata = parsedResult.getSecond();
+        }
 
         return aceDoc;
     }


### PR DESCRIPTION
Addressed #160 

- Adds Attributes to TextAnnotation. Also defined a common interface `HasAttributes` for all attribute related methods used by - TextAnnotation, Constituent, Relation.
- Defined `DocumentMetadata` class for constants related to a document.
- ACEReader adds non-empty metadata files to the generated TextAnnotation.