### PR TITLE
added option to split words on "-".

### DIFF
--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
@@ -16,6 +16,7 @@ import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.annotationStructure.*
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader.AceFileProcessor;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.aceReader.documentReader.ReadACEAnnotation;
 import edu.illinois.cs.cogcomp.nlp.tokenizer.IllinoisTokenizer;
+import edu.illinois.cs.cogcomp.nlp.tokenizer.StatefulTokenizer;
 import edu.illinois.cs.cogcomp.nlp.utility.TokenizerTextAnnotationBuilder;
 
 import org.slf4j.Logger;
@@ -56,7 +57,7 @@ public class ACEReader extends TextAnnotationReader {
     private static final String RelationSecondArgumentTag = "Arg-2";
     private static final Logger logger = LoggerFactory.getLogger(ACEReader.class);
     private static final AceFileProcessor fileProcessor = new AceFileProcessor();
-    private static final TextAnnotationBuilder taBuilder = new TokenizerTextAnnotationBuilder(new IllinoisTokenizer());
+    private static final TextAnnotationBuilder taBuilder = new TokenizerTextAnnotationBuilder(new StatefulTokenizer(false));
     private final String aceCorpusHome;
     private final boolean is2004mode;
     private final String corpusId;

--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefulTokenizer.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefulTokenizer.java
@@ -10,7 +10,6 @@ package edu.illinois.cs.cogcomp.nlp.tokenizer;
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 import edu.illinois.cs.cogcomp.nlp.tokenizer.TokenizerStateMachine.State;
-import edu.illinois.cs.cogcomp.nlp.utility.TokenizerTextAnnotationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,12 +20,36 @@ import org.slf4j.LoggerFactory;
  * @author redman
  */
 public class StatefulTokenizer implements Tokenizer {
+    
+    /** the logger specific to this class. */
     private static Logger logger = LoggerFactory.getLogger(StatefulTokenizer.class);
 
+    /** this is set to split tokens where dashes are found within words. */
+    private boolean splitOnDash = true;
+    
+    /**
+     * Takes a boolean indicating if we are to split on dash or not. The default
+     * constructor assumes we do split on dash.
+     * @param splitOnDash if true, we will split words on a "-".
+     */
+    public StatefulTokenizer () {
+        super();
+    }
+    
+    /**
+     * Takes a boolean indicating if we are to split on dash or not. The default
+     * constructor assumes we do split on dash.
+     * @param splitOnDash if true, we will split words on a "-".
+     */
+    public StatefulTokenizer (boolean splitOnDash) {
+        super();
+        this.splitOnDash = splitOnDash;
+    }
+    
     @Override
     public Pair<String[], IntPair[]> tokenizeSentence(String sentence) {
         // parse the test
-        TokenizerStateMachine tsm = new TokenizerStateMachine();
+        TokenizerStateMachine tsm = new TokenizerStateMachine(splitOnDash);
         tsm.parseText(sentence);
 
         // construct the data needed for the tokenization.
@@ -53,7 +76,7 @@ public class StatefulTokenizer implements Tokenizer {
     public Tokenization tokenizeTextSpan(String textSpan) {
 
         // parse the text
-        TokenizerStateMachine tsm = new TokenizerStateMachine();
+        TokenizerStateMachine tsm = new TokenizerStateMachine(splitOnDash);
         tsm.parseText(textSpan);
 
         // construct the data needed for the tokenization.
@@ -89,5 +112,19 @@ public class StatefulTokenizer implements Tokenizer {
                 sentenceEnds = temp;
             }
         return new Tokenization(tokens, wordOffsets, sentenceEnds);
+    }
+
+    /**
+     * @return the splitOnDash to split words when dash encounter or not.
+     */
+    public boolean isSplitOnDash() {
+        return splitOnDash;
+    }
+
+    /**
+     * @param splitOnDash the splitOnDash to set
+     */
+    public void setSplitOnDash(boolean splitOnDash) {
+        this.splitOnDash = splitOnDash;
     }
 }

--- a/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
+++ b/tokenizer/src/main/java/edu/illinois/cs/cogcomp/nlp/tokenizer/TokenizerStateMachine.java
@@ -46,8 +46,6 @@ import java.util.regex.Pattern;
  * <li>contractions with abbr, like can't, won't and those. if no spaces surround the "'", we will
  * leave the word together including the "'" unless it is one of the common contractions like 's,
  * 'm, 're, et cetera.
- * <li>O'Malley, O'Brien and do on. FIXED.
- * <li>Abbreviation followed by punctuation is not caught. FIXED.
  * </ol>
  * 
  * @author redman
@@ -94,18 +92,17 @@ public class TokenizerStateMachine {
 
     /** the state we are in currently. */
     protected int state;
-
+    
     /**
      * Init the state machine decision matrix and the text annotation.
      */
-    public TokenizerStateMachine() {
+    public TokenizerStateMachine(final boolean splitOnDash) {
         // cardinality of 1st dim the number of states(TokenizerState), 2nd is the number of token
         // types (TokenType enum)
         StateProcessor[][] toopy = { {
 
                 // process tokens in sentence, we are only in a sentences while processing white
-                // space There
-                // is always a sentence on top of the stack.
+                // space. There is always a sentence on top of the stack.
 
                 /** get punctuation while in sentence. This starts a new word. */
                 new StateProcessor() {
@@ -202,7 +199,6 @@ public class TokenizerStateMachine {
                                                                                      // token.
                                 break;
                             case '-': {
-
                                 // If there is a character before and after, this is a word.
                                 char after = peek(1);
                                 char before = peek(-1);
@@ -210,13 +206,11 @@ public class TokenizerStateMachine {
                                     /*
                                          if (!((Character.isAlphabetic(before) || Character.isDigit(before)) && (Character
                                                 .isAlphabetic(after) || Character.isDigit(after)))) {*/
-                                    pop(current); // the current word is finished.
-                                    push(new State(TokenizerState.IN_SPECIAL), current); // No
-                                                                                         // matter
-                                                                                         // what we
-                                                                                         // push a
-                                                                                         // new word
-                                                                                         // token.
+                                    
+                                    if (splitOnDash == true) {
+                                        pop(current); // the current word is finished.
+                                        push(new State(TokenizerState.IN_SPECIAL), current);
+                                    }
                                 }
                                 return;
                             }
@@ -286,10 +280,7 @@ public class TokenizerStateMachine {
                                     // it's a time, or bible passage.
                                     return;
                                 pop(current); // the current word is finished.
-                                push(new State(TokenizerState.IN_SPECIAL), current); // No matter
-                                                                                     // what we push
-                                                                                     // a new word
-                                                                                     // token.
+                                push(new State(TokenizerState.IN_SPECIAL), current);
                                 break;
                             }
                             case '.': {
@@ -336,10 +327,7 @@ public class TokenizerStateMachine {
                             }
                             default:
                                 pop(current); // the current word is finished.
-                                push(new State(TokenizerState.IN_SPECIAL), current); // No matter
-                                                                                     // what we push
-                                                                                     // a new word
-                                                                                     // token.
+                                push(new State(TokenizerState.IN_SPECIAL), current);
                                 break;
                         }
                     }

--- a/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
+++ b/tokenizer/src/test/java/edu/illinois/cs/cogcomp/nlp/tokenizer/StatefullTokenizerTest.java
@@ -267,7 +267,7 @@ public class StatefullTokenizerTest {
     }
 
     @Test
-    public void testStatefullTokenizerEmptyString() {
+    public void testEmptyString() {
         Tokenizer tkr = new StatefulTokenizer();
         String text = "";
         Tokenizer.Tokenization tknzn = tkr.tokenizeTextSpan(text);
@@ -275,11 +275,20 @@ public class StatefullTokenizerTest {
     }
 
     @Test
-    public void testStatefullTokenizerStringWithNewline() {
+    public void testStringWithNewline() {
         Tokenizer tkr = new StatefulTokenizer();
         String text = "this\nsentence";
         Tokenizer.Tokenization tknzn = tkr.tokenizeTextSpan(text);
         assertEquals(tknzn.getTokens().length, 2);
+    }
+    @Test
+    public void testSplitOnDash() {
+        Tokenizer tkr = new StatefulTokenizer();
+        String text = "IAEA Director-General Mohamed ElBaradei";
+        Tokenizer.Tokenization tknzn = tkr.tokenizeTextSpan(text);
+        for (String token : tknzn.getTokens())
+            System.out.println("token : "+token);
+        assertEquals(tknzn.getTokens().length, 6);
     }
 
 }


### PR DESCRIPTION
Added an option to text splitter to split words on "-". Default behavior is same, it does split on "-", if you pass true to the constructor, or call the setter, opposite behavior results.