### PR TITLE
Minor fixes to Pipeline README

### DIFF
--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -96,10 +96,8 @@ of several other components for which it is a dependency.
 
 ### 1.3 LICENSE
 
-## Licensing
 To see the full license for this software, see [LICENSE](../master/LICENSE) or visit the [download page](http://cogcomp.cs.illinois.edu/page/software_view/NETagger) for this software
 and press 'Download'. The next screen displays the license.
-
 
 ## 2 PREREQUISITES
 
@@ -172,11 +170,6 @@ If this package is used in maven, please add the following dependencies with pro
         <groupId>edu.illinois.cs.cogcomp</groupId>
         <artifactId>illinois-nlp-pipeline</artifactId>
         <version>3.0.86</version>
-    </dependency>
-    <dependency>
-        <groupId>edu.stanford.nlp</groupId>
-        <artifactId>stanford-corenlp</artifactId>
-        <version>3.3.1</version>
     </dependency>
 </dependencies>
 <repositories>
@@ -330,8 +323,16 @@ This project uses slf4j's log4j libraries.  You can change the
 settings by creating a log4j.properties file and adding the directory
 containing that file to the classpath.
 
-### 6.3 Troubleshooting
-Please be noted that there should not be two active `PipelineFactory` in a single run. For example, the following code yields run-time errors:
+### 6.3 Frequently Asked Questions (FAQs)
+
+- While running the Pipeline if you see an error regarding insufficient Java heap space, you will need to set the `JAVA_OPTIONS` or `MAVEN_OPTIONS` to include "-Xmx20g"
+
+- Between different runs of the Pipeline, if you see the following exception, you should remove the temporary cache folders created by MapDB.
+```java
+Caused by: org.mapdb.DBException$DataCorruption: Header checksum broken. Store was not closed correctly, or is corrupted
+```
+
+- Initializing multiple instances of `PipelineFactory` in a single run will lead to an exception in MapDB. For example, the code below:
 ```java
 public class testpipeline {
     public static TextAnnotation getTA(String id, String text) throws Exception{
@@ -348,6 +349,7 @@ public class testpipeline {
     }
 }
 ```
+would lead to the following exception:
 ```java
 Exception in thread "main" org.mapdb.DBException$FileLocked: File is already opened and is locked: annotation-cache
 	at org.mapdb.volume.Volume.lockFile(Volume.java:446)
@@ -360,6 +362,7 @@ Caused by: java.nio.channels.OverlappingFileLockException
 	at sun.nio.ch.FileChannelImpl.lock(FileChannelImpl.java:1030)
 	...
 ```
+
 To fix this problem, consider changing it to:
 ```java
 public class testpipeline {

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -170,11 +170,6 @@ If this package is used in maven, please add the following dependencies with pro
 <dependencies>
     <dependency>
         <groupId>edu.illinois.cs.cogcomp</groupId>
-        <artifactId>illinois-core-utilities</artifactId>
-        <version>3.0.86</version>
-    </dependency>
-    <dependency>
-        <groupId>edu.illinois.cs.cogcomp</groupId>
         <artifactId>illinois-nlp-pipeline</artifactId>
         <version>3.0.86</version>
     </dependency>
@@ -182,12 +177,6 @@ If this package is used in maven, please add the following dependencies with pro
         <groupId>edu.stanford.nlp</groupId>
         <artifactId>stanford-corenlp</artifactId>
         <version>3.3.1</version>
-    </dependency>
-    <dependency>
-        <groupId>edu.stanford.nlp</groupId>
-        <artifactId>stanford-corenlp</artifactId>
-        <version>3.3.1</version>
-        <classifier>models</classifier>
     </dependency>
 </dependencies>
 <repositories>
@@ -252,12 +241,17 @@ edu.illinois.cs.cogcomp.pipeline.main.
 
 To process text input, use the '()' method:
 ```java
+import edu.illinois.cs.cogcomp.annotation.AnnotatorService;
+import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
+import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
+import edu.illinois.cs.cogcomp.pipeline.main.PipelineFactory;
+
 String docId = "APW-20140101.3018"; // arbitrary string identifier
 String textId = "body"; // arbitrary string identifier
 String text = ...; // contains plain text to be annotated
 
 ResourceManager rm = new ResourceManager( "config/pipeline-config.properties" );
-AnnotatorService pipeline = IllinoisPipelineFactory.buildPipeline( rm );
+AnnotatorService pipeline = PipelineFactory.buildPipeline( rm );
 TextAnnotation ta = pipeline.createAnnotatedTextAnnotation( docId, textId, text );
 ```
 This method takes as its argument a String variable containing the

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -28,7 +28,7 @@ Illinois Cognitive Computation Group's web site:
 To process a set of plain text files in one directory and generate
 a corresponding set of annotated files in json format in a second
 directory, run the command:
-```
+```sh
 scripts/runPipelineOnDataset.sh  <configFile> <inputDirectory> <outputDirectory>
 ```
 The configuration file needs only to contain options to override defaults.
@@ -166,7 +166,7 @@ we recommend checking out the project from [github](https://github.com/IllinoisC
 
 ## 4. Dependencies
 If this package is used in maven, please add the following dependencies with proper reepositories.
-```
+```xml
 <dependencies>
     <dependency>
         <groupId>edu.illinois.cs.cogcomp</groupId>
@@ -218,12 +218,12 @@ differences.
 ### 5.1 Running a Simple Command-Line Test
 
 Running the test:
-```
+```sh
 scripts/testPreprocessor.sh
 ```
 
 Running your own text to get a visual sense of what IllinoisPreprocessor is doing:
-```
+```sh
 scripts/runPreprocessor.sh  config/pipelineConfig.txt [yourTextFile] > [yourOutputFile]
 ```
 
@@ -244,13 +244,14 @@ To process text input, use the '()' method:
 import edu.illinois.cs.cogcomp.annotation.AnnotatorService;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.TextAnnotation;
 import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
+import edu.illinois.cs.cogcomp.pipeline.common.PipelineConfigurator;
 import edu.illinois.cs.cogcomp.pipeline.main.PipelineFactory;
 
 String docId = "APW-20140101.3018"; // arbitrary string identifier
 String textId = "body"; // arbitrary string identifier
 String text = ...; // contains plain text to be annotated
 
-ResourceManager rm = new ResourceManager( "config/pipeline-config.properties" );
+ResourceManager rm = new PipelineConfigurator().getConfig(new ResourceManager( "config/pipeline-config.properties" ));
 AnnotatorService pipeline = PipelineFactory.buildPipeline( rm );
 TextAnnotation ta = pipeline.createAnnotatedTextAnnotation( docId, textId, text );
 ```
@@ -331,7 +332,7 @@ containing that file to the classpath.
 
 ### 6.3 Troubleshooting
 Please be noted that there should not be two active `PipelineFactory` in a single run. For example, the following code yields run-time errors:
-```
+```java
 public class testpipeline {
     public static TextAnnotation getTA(String id, String text) throws Exception{
         ResourceManager rm = new PipelineConfigurator().getConfig(new ResourceManager( "pipeline-config.properties" ));
@@ -347,7 +348,7 @@ public class testpipeline {
     }
 }
 ```
-```
+```java
 Exception in thread "main" org.mapdb.DBException$FileLocked: File is already opened and is locked: annotation-cache
 	at org.mapdb.volume.Volume.lockFile(Volume.java:446)
 	at org.mapdb.volume.RandomAccessFileVol.<init>(RandomAccessFileVol.java:52)
@@ -360,7 +361,7 @@ Caused by: java.nio.channels.OverlappingFileLockException
 	...
 ```
 To fix this problem, consider changing it to:
-```
+```java
 public class testpipeline {
     public static TextAnnotation getTA(String id, String text, AnnotatorService prep) throws Exception{
         TextAnnotation rec = prep.createAnnotatedTextAnnotation(id, "", text);


### PR DESCRIPTION
- Update `PipelineFactory` class name.
- Add imports required to run the given code. [It is difficult to search for the actual namespaces while running]
- Remove dependencies that are not required for programmatic usage.

Pending:
The default set of configuration does not seem to work with pipeline. Will PR with correct default in a while.