### PR TITLE
[Pipeline/Webserver] Add support for CLI arguments - Port number

### DIFF
--- a/ner/pom.xml
+++ b/ner/pom.xml
@@ -90,6 +90,7 @@
            <plugin>
                <groupId>org.apache.maven.plugins</groupId>
                <artifactId>maven-surefire-plugin</artifactId>
+               <version>2.19.1</version>
 			    <configuration>
 			        <forkCount>1</forkCount>
 			        <reuseForks>false</reuseForks>

--- a/pipeline/README.md
+++ b/pipeline/README.md
@@ -164,7 +164,7 @@ all its components.  If you want to experiment with different settings,
 we recommend checking out the project from [github](https://github.com/IllinoisCogComp/illinois-cogcomp-nlp) -- see the section on Programmatic Use.
 
 ## 4. Dependencies
-If this package is used in maven, please add the following dependencies with proper reepositories.
+If this package is used in maven, please add the following dependencies with proper repositories.
 ```xml
 <dependencies>
     <dependency>
@@ -178,11 +178,6 @@ If this package is used in maven, please add the following dependencies with pro
         <id>CogcompSoftware</id>
         <name>CogcompSoftware</name>
         <url>http://cogcomp.cs.illinois.edu/m2repo/</url>
-    </repository>
-    <repository>
-        <id>StanfordNLP</id>
-        <name>StanfordNLP</name>
-        <url>http://central.maven.org/maven2/</url>
     </repository>
 </repositories>
 ```
@@ -389,10 +384,19 @@ public class testpipeline {
 
 Our pipeline contains a webserver which can be run on a remote server. The server supports post and get requests to obtain annotation for a requested text, with desired views. 
 
-In order to run the webserver, do: 
+In order to run the webserver with default settings (port = 8080), do: 
 
 ```shell
-./pipeline/scripts/runWebserver.sh
+pipeline/scripts/runWebserver.sh
+```
+
+The following arguments are supported:
+```shell
+usage: pipeline/scripts/runWebserver.sh [-h] [--port PORT]
+
+optional arguments:
+  -h, --help             show this help message and exit
+  --port PORT, -P PORT   Port to run the webserver.
 ```
 
 Here are the available APIs: 

--- a/pipeline/pom.xml
+++ b/pipeline/pom.xml
@@ -101,6 +101,11 @@
             <version>6.5</version>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.argparse4j</groupId>
+            <artifactId>argparse4j</artifactId>
+            <version>0.7.0</version>
+        </dependency>
 
         <!--for pipeline web-server-->
         <dependency>

--- a/pipeline/scripts/runWebserver.sh
+++ b/pipeline/scripts/runWebserver.sh
@@ -2,4 +2,4 @@
 
 export MAVEN_OPTS="-Xmx35g"
 
-mvn -pl pipeline compile  exec:java -Dexec.mainClass=edu.illinois.cs.cogcomp.pipeline.server.MainServer # -DargLine="-Xmx10g"
+mvn -pl pipeline compile  exec:java -Dexec.mainClass=edu.illinois.cs.cogcomp.pipeline.server.MainServer -Dexec.args="$*" # -DargLine="-Xmx10g"

--- a/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/server/MainServer.java
+++ b/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/server/MainServer.java
@@ -35,7 +35,7 @@ public class MainServer {
 
     static {
         // Setup Argument Parser with options.
-        argumentParser = ArgumentParsers.newArgumentParser("test")
+        argumentParser = ArgumentParsers.newArgumentParser("pipeline/scripts/runWebserver.sh")
                 .description("Pipeline Webserver.");
         argumentParser.addArgument("--port", "-P")
                 .type(Integer.class)

--- a/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/server/MainServer.java
+++ b/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/server/MainServer.java
@@ -15,6 +15,11 @@ import edu.illinois.cs.cogcomp.core.utilities.configuration.ResourceManager;
 import edu.illinois.cs.cogcomp.pipeline.common.PipelineConfigurator;
 import edu.illinois.cs.cogcomp.pipeline.handlers.StanfordDepHandler;
 import edu.illinois.cs.cogcomp.pipeline.main.PipelineFactory;
+import net.sourceforge.argparse4j.ArgumentParsers;
+import net.sourceforge.argparse4j.inf.ArgumentParser;
+import net.sourceforge.argparse4j.inf.ArgumentParserException;
+import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.internal.HelpScreenException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,8 +31,32 @@ public class MainServer {
 
     private static Logger logger = LoggerFactory.getLogger(StanfordDepHandler.class);
 
+    private static ArgumentParser argumentParser;
+
+    static {
+        // Setup Argument Parser with options.
+        argumentParser = ArgumentParsers.newArgumentParser("test")
+                .description("Pipeline Webserver.");
+        argumentParser.addArgument("--port", "-P")
+                .type(Integer.class)
+                .setDefault(8080)
+                .dest("port")
+                .help("Port to run the webserver.");
+    }
+
     public static void main(String[] args) {
-        port(8080);
+        Namespace parseResults;
+
+        try {
+             parseResults = argumentParser.parseArgs(args);
+        } catch (HelpScreenException ex) {
+            return;
+        } catch (ArgumentParserException ex) {
+            logger.error("Exception while parsing arguments", ex);
+            return;
+        }
+
+        port(parseResults.getInt("port"));
 
         AnnotatorService pipeline = null;
         try {

--- a/pipeline/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/CachingPipelineTest.java
+++ b/pipeline/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/CachingPipelineTest.java
@@ -168,7 +168,8 @@ public class CachingPipelineTest
                 "       :LABEL:aux has\n" +
                 "       (:LABEL:prep on (:LABEL:pobj significance :LABEL:det a))\n" +
                 "       (:LABEL:prep beyond (:LABEL:pobj that (:LABEL:prep in :LABEL:pobj Mexico))))";
-        assert predictedDepTree.trim().equals(goldDepTree);
+        assertEquals("DEPENDENCY_STANFORD - Dependency parse tree should match gold parse.",
+                predictedDepTree.trim(), goldDepTree);
 
         String predictedParseTree = basicTextAnnotation.getView(ViewNames.PARSE_STANFORD).toString();
         String goldParseTree = "(ROOT (S (PP (IN In)\n" +
@@ -189,6 +190,7 @@ public class CachingPipelineTest
                 "                   (PP (IN in)\n" +
                 "                       (NP (NNP Mexico)))))))\n" +
                 "   (. .)))";
-        assert predictedParseTree.trim().equals(goldParseTree);
+        assertEquals("PARSE_STANFORD - Constituency parse tree  generated should match gold parse.",
+                predictedParseTree.trim(), goldParseTree);
     }
 }


### PR DESCRIPTION
This bring in a dependency for parsing CLI arguments. Can add custom argument parsing logic if we do not want to use the dependency.

(Or we can build a common argument parser in core-utils) comments?

Also fixed #308 