### PR TITLE
bug fix in ERE reader

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/JsonSerializer.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/utilities/JsonSerializer.java
@@ -7,6 +7,7 @@
  */
 package edu.illinois.cs.cogcomp.core.utilities;
 
+import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
 
@@ -22,6 +23,7 @@ import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
 import edu.illinois.cs.cogcomp.core.datastructures.Pair;
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
+import edu.illinois.cs.cogcomp.nlp.utilities.TextAnnotationPrintHelper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +35,8 @@ public class JsonSerializer extends AbstractSerializer {
     public static final String TOKENOFFSETS = "tokenOffsets";
     public static final String LABEL_SCORE_MAP = "labelScoreMap";
     public static final String PROPERTIES = "properties";
-    private final Logger logger = LoggerFactory.getLogger(JsonSerializer.class);
+    private static final boolean DEBUG = true;
+    private static final Logger logger = LoggerFactory.getLogger(JsonSerializer.class);
 
     /**
      * Add an array of objects reporting View's Constituents' surface form and character offsets.
@@ -68,6 +71,13 @@ public class JsonSerializer extends AbstractSerializer {
 
         List<Constituent> constituents = view.getConstituents();
 
+        try {
+            logger.debug(TextAnnotationPrintHelper.printView(view));
+            if (DEBUG)
+                System.err.println(TextAnnotationPrintHelper.printView(view));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
         if (constituents.size() > 0) {
             JsonArray cJson = new JsonArray();
             for (int i = 0; i < view.getNumberOfConstituents(); i++) {
@@ -94,6 +104,13 @@ public class JsonSerializer extends AbstractSerializer {
 
                 int srcId = constituents.indexOf(src);
                 int tgtId = constituents.indexOf(tgt);
+
+                if (srcId < 0)
+                    throw new IllegalStateException("ERROR: Couldn't find index in constituent list for argument constituent: " +
+                            TextAnnotationPrintHelper.printConstituent(src));
+                if (tgtId < 0)
+                    throw new IllegalStateException("ERROR: Couldn't find index in constituent list for argument constituent: " +
+                            TextAnnotationPrintHelper.printConstituent(tgt));
 
                 JsonObject rJ = new JsonObject();
 

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
@@ -61,6 +61,9 @@ public class EREMentionRelationReader extends ERENerReader {
 
             Document doc = SimpleXMLParser.getDocument(corpusFileListEntry.get(i).toFile());
             super.getEntitiesFromFile(doc, mentionView);
+            super.getFillersFromFile(doc, mentionView);
+
+
             /**
              * previous call populates mentionID : Constituent map needed to build relations efficiently
              */
@@ -122,6 +125,7 @@ public class EREMentionRelationReader extends ERENerReader {
 
             if (null == arg1c || null == arg2c) {
                 numRelationsMissed++;
+                continue;
             }
             nnMap = relMentionNode.getAttributes();
             String realis = nnMap.getNamedItem(REALIS).getNodeValue();

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
@@ -79,10 +79,10 @@ public class EREMentionRelationReader extends ERENerReader {
      */
     private void getRelationsFromFile(Document doc, CoreferenceView mentionView) throws XMLException {
         Element element = doc.getDocumentElement();
-        Element entityElement = SimpleXMLParser.getElement(element, RELATIONS);
-        NodeList entityNL = entityElement.getElementsByTagName(RELATION);
-        for (int j = 0; j < entityNL.getLength(); ++j) {
-            readRelation(entityNL.item(j), mentionView);
+        Element relElement = SimpleXMLParser.getElement(element, RELATIONS);
+        NodeList relNL = relElement.getElementsByTagName(RELATION);
+        for (int j = 0; j < relNL.getLength(); ++j) {
+            readRelation(relNL.item(j), mentionView);
         }
         logger.info("number of missed relations (missing argument): {}", numRelationsMissed );
     }
@@ -114,16 +114,16 @@ public class EREMentionRelationReader extends ERENerReader {
         // now for specifics get the mentions.
         NodeList nl = ((Element)node).getElementsByTagName(RELATION_MENTION);
         for (int i = 0; i < nl.getLength(); ++i) {
-            Node mentionNode = nl.item(i);
-            Pair<String, String> arg1Info = getArgumentId(mentionNode, ARG_ONE);
-            Pair<String, String> arg2Info = getArgumentId(mentionNode, ARG_TWO);
+            Node relMentionNode = nl.item(i);
+            Pair<String, String> arg1Info = getArgumentId(relMentionNode, ARG_ONE);
+            Pair<String, String> arg2Info = getArgumentId(relMentionNode, ARG_TWO);
             Constituent arg1c = super.getMentionConstituent(arg1Info.getFirst());
             Constituent arg2c = super.getMentionConstituent(arg2Info.getFirst());
 
             if (null == arg1c || null == arg2c) {
                 numRelationsMissed++;
             }
-            nnMap = mentionNode.getAttributes();
+            nnMap = relMentionNode.getAttributes();
             String realis = nnMap.getNamedItem(REALIS).getNodeValue();
             String mentionId = nnMap.getNamedItem(ID).getNodeValue();
 

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
@@ -35,8 +35,6 @@ import java.util.*;
  *     mention view via its type attribute.
  *
  * TODO: ascertain whether NER mentions can overlap. Probably not.
- * TODO: add fillers (non-specific entity mentions)
- * TODO: add entity id and mention id
  * TODO: allow non-token-level annotations (i.e. subtokens)
  *
  * This code is based on Tom Redman's code for generating CoNLL-format ERE NER data.
@@ -164,11 +162,18 @@ public class ERENerReader extends EREDocumentReader {
             readFiller(fillerNl.item(i), nerView);
     }
 
-    private void readFiller(Node fillerNode, View view) {
+    /**
+     * WARNING: filler can have null value.
+     * @param fillerNode
+     * @param view
+     */
+    private void readFiller(Node fillerNode, View view) throws XMLException {
         NamedNodeMap nnMap = fillerNode.getAttributes();
         int offset = Integer.parseInt(nnMap.getNamedItem(OFFSET).getNodeValue());
         int length = Integer.parseInt(nnMap.getNamedItem(LENGTH).getNodeValue());
-        String fillerForm = fillerNode.getNodeValue();
+        String fillerForm = SimpleXMLParser.getContentString((Element) fillerNode);
+        if ( null == fillerForm || "".equals(fillerForm))
+            throw new IllegalStateException("ERROR: did not find surface form for filler " + nnMap.getNamedItem(ID).getNodeValue());
         IntPair offsets = getOffsets(offset, length, fillerForm, view);
         if (null != offsets) {
             String fillerId = nnMap.getNamedItem(ID).getNodeValue();

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/EREReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/EREReaderTest.java
@@ -9,9 +9,16 @@ package edu.illinois.cs.cogcomp.nlp.corpusreaders;
 
 import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 import edu.illinois.cs.cogcomp.core.datastructures.textannotation.*;
+import edu.illinois.cs.cogcomp.core.io.LineIO;
+import edu.illinois.cs.cogcomp.core.utilities.SerializationHelper;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.ereReader.EREMentionRelationReader;
 import edu.illinois.cs.cogcomp.nlp.corpusreaders.ereReader.ERENerReader;
 import edu.illinois.cs.cogcomp.nlp.utilities.TextAnnotationPrintHelper;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static org.junit.Assert.fail;
 
 
 /**
@@ -22,7 +29,7 @@ import edu.illinois.cs.cogcomp.nlp.utilities.TextAnnotationPrintHelper;
 public class EREReaderTest {
     private static final String NAME = EREReaderTest.class.getCanonicalName();
 
-
+    private static boolean doSerialize = true;
 
 //    public void testNerReader() {
     public static void main(String[] args) {
@@ -88,5 +95,14 @@ public class EREReaderTest {
 
         System.err.println(TextAnnotationPrintHelper.printCoreferenceView(cView));
 
+        if (doSerialize) {
+            String jsonStr = SerializationHelper.serializeToJson(output);
+            try {
+                LineIO.write("EREsample.json", Collections.singletonList(jsonStr));
+            } catch (IOException e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+            }
+        }
     }
 }

--- a/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/EREReaderTest.java
+++ b/corpusreaders/src/test/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/EREReaderTest.java
@@ -103,6 +103,19 @@ public class EREReaderTest {
                 e.printStackTrace();
                 fail(e.getMessage());
             }
+
+
+            TextAnnotation newTa = null;
+
+            try {
+                newTa = SerializationHelper.deserializeFromJson(jsonStr);
+            } catch (Exception e) {
+                e.printStackTrace();
+                fail(e.getMessage());
+            }
+
         }
+
+
     }
 }

--- a/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/server/MainServer.java
+++ b/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/server/MainServer.java
@@ -29,7 +29,7 @@ import static spark.Spark.*;
 
 public class MainServer {
 
-    private static Logger logger = LoggerFactory.getLogger(StanfordDepHandler.class);
+    private static Logger logger = LoggerFactory.getLogger(MainServer.class);
 
     private static ArgumentParser argumentParser;
 


### PR DESCRIPTION
Mentions of type 'filler' were being created with empty surface forms, resulting in errors downstream. Added a fix and an explicit check in the reader.