### PR TITLE
fix bug in ERE reader

### DIFF
--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
@@ -98,6 +98,7 @@ public class ERENerReader extends EREDocumentReader {
     public List<TextAnnotation> getTextAnnotationsFromFile(List<Path> corpusFileListEntry) throws Exception {
 
         mentionIdToConstituent.clear();
+        entityIdToMentionIds.clear();
 
         TextAnnotation sourceTa = super.getTextAnnotationsFromFile(corpusFileListEntry).get(0);
         SpanLabelView tokens = (SpanLabelView) sourceTa.getView(ViewNames.TOKENS);

--- a/ner/src/main/java/edu/illinois/cs/cogcomp/ner/LbjTagger/NEWord.java
+++ b/ner/src/main/java/edu/illinois/cs/cogcomp/ner/LbjTagger/NEWord.java
@@ -8,7 +8,6 @@
 package edu.illinois.cs.cogcomp.ner.LbjTagger;
 
 
-import com.sun.org.apache.bcel.internal.generic.NEW;
 import edu.illinois.cs.cogcomp.ner.LbjTagger.ParametersForLbjCode.TokenizationScheme;
 import edu.illinois.cs.cogcomp.ner.StringStatisticsUtils.CharacteristicWords;
 import edu.illinois.cs.cogcomp.lbjava.nlp.SentenceSplitter;


### PR DESCRIPTION
fixed problem where null pointer exception occurred when reading multiple documents due to incorrect cleanup of state between document reads. 