### PR TITLE
sentence-by-sentence pipeline

### DIFF
--- a/core-utilities/README.md
+++ b/core-utilities/README.md
@@ -377,7 +377,15 @@ argument to the `Annotator` constructor. This is used for lazy
 initialization, if active, in which case the first call to `getView()`
 will call `initialize()` with this configuration. 
 
-One key configuration default, AnnotatorConfig.
+One key configuration default, `AnnotatorConfigurator.IS_SENTENCE_LEVEL`
+indicates whether an annotator requires context beyond a single sentence.
+For example, when the POS tagger predicts a label for a word, it uses
+only information from the same sentence. This means that a document
+can be split up into sentences, which can then be processed one at a 
+time by the POS annotator, without degrading accuracy. NER,
+on the other hand, has features that depend on a context that may 
+extend into previous sentences: if the sentence-by-sentence approach
+is used for NER, some degradation is to be expected. 
 
 ###Configurators
 

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/CoreferenceView.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/CoreferenceView.java
@@ -8,7 +8,6 @@
 package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
 import edu.illinois.cs.cogcomp.core.algorithms.Mappers;
-import edu.illinois.cs.cogcomp.core.algorithms.ProducerConsumer;
 import edu.illinois.cs.cogcomp.core.algorithms.Sorters;
 import edu.illinois.cs.cogcomp.core.transformers.ITransformer;
 import gnu.trove.map.hash.TIntIntHashMap;

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotationUtilities.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotationUtilities.java
@@ -11,6 +11,7 @@ package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 import edu.illinois.cs.cogcomp.annotation.BasicTextAnnotationBuilder;
 import edu.illinois.cs.cogcomp.core.datastructures.HasAttributes;
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
+import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 
 import java.io.PrintStream;
 import java.util.*;

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotationUtilities.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/core/datastructures/textannotation/TextAnnotationUtilities.java
@@ -10,7 +10,6 @@ package edu.illinois.cs.cogcomp.core.datastructures.textannotation;
 
 import edu.illinois.cs.cogcomp.annotation.BasicTextAnnotationBuilder;
 import edu.illinois.cs.cogcomp.core.datastructures.IntPair;
-import edu.illinois.cs.cogcomp.core.datastructures.ViewNames;
 
 import java.io.PrintStream;
 import java.util.*;

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ACEReader.java
@@ -478,4 +478,16 @@ public class ACEReader extends TextAnnotationReader {
 
         return textAnnotation != null;
     }
+
+
+    /**
+     * TODO: generate a human-readable report of annotations read from the source file (plus whatever
+     * other relevant statistics the user should know about).
+     */
+
+    public String generateReport() {
+        throw new UnsupportedOperationException("ERROR: generateReport() Not yet implemented.");
+    }
+
+
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/AbstractIncrementalCorpusReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/AbstractIncrementalCorpusReader.java
@@ -147,6 +147,8 @@ public abstract class AbstractIncrementalCorpusReader extends TextAnnotationRead
      * other relevant statistics the user should know about).
      */
 
-    abstract public String generateReport();
+    public String generateReport() {
+        throw new UnsupportedOperationException("ERROR: generateReport() Not yet implemented.");
+    }
 
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/CoNLLColumnFormatReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/CoNLLColumnFormatReader.java
@@ -34,14 +34,13 @@ import java.util.Scanner;
  */
 public class CoNLLColumnFormatReader extends TextAnnotationReader {
 
-    protected final String predicateArgumentViewName;
-    private final TextAnnotationBuilder textAnnotationBuilder;
-    protected int currentLine;
-    protected final ArrayList<String> lines;
-    protected final String section;
-
     private static org.slf4j.Logger logger =
             LoggerFactory.getLogger(CoNLLColumnFormatReader.class);
+    protected final String predicateArgumentViewName;
+    protected final ArrayList<String> lines;
+    protected final String section;
+    private final TextAnnotationBuilder textAnnotationBuilder;
+    protected int currentLine;
     /**
      * Initialize the reader.
      *
@@ -77,6 +76,36 @@ public class CoNLLColumnFormatReader extends TextAnnotationReader {
         }
     }
 
+    public static void main(String[] args) throws Exception {
+        String columnFile = "02.feats";
+
+        CoNLLColumnFormatReader reader =
+                new CoNLLColumnFormatReader("PennTreebank-WSJ", "02", columnFile,
+                        ViewNames.SRL_VERB, new BasicTextAnnotationBuilder());
+
+        Counter<String> counter = new Counter<>();
+
+        List<String> predicates = new ArrayList<>();
+
+        for (TextAnnotation ta : reader) {
+            counter.incrementCount("Sentences");
+            System.out.println(ta.getTokenizedText());
+
+            if (!ta.hasView(ViewNames.SRL_VERB))
+                continue;
+
+            PredicateArgumentView pav = (PredicateArgumentView) ta.getView(ViewNames.SRL_VERB);
+            List<Constituent> predicates2 = pav.getPredicates();
+            counter.incrementCount("Predicates", predicates2.size());
+            for (Constituent c : predicates2) {
+                predicates.add(c.getAttribute(PredicateArgumentView.LemmaIdentifier));
+            }
+
+        }
+
+        System.out.println((int) counter.getCount("Sentences") + " sentences");
+        System.out.println((int) counter.getCount("Predicates") + " predicates");
+    }
 
     public boolean hasNext() {
         return currentLine < lines.size();
@@ -330,35 +359,13 @@ public class CoNLLColumnFormatReader extends TextAnnotationReader {
 
     }
 
-    public static void main(String[] args) throws Exception {
-        String columnFile = "02.feats";
+    /**
+     * TODO: generate a human-readable report of annotations read from the source file (plus whatever
+     * other relevant statistics the user should know about).
+     */
 
-        CoNLLColumnFormatReader reader =
-                new CoNLLColumnFormatReader("PennTreebank-WSJ", "02", columnFile,
-                        ViewNames.SRL_VERB, new BasicTextAnnotationBuilder());
-
-        Counter<String> counter = new Counter<>();
-
-        List<String> predicates = new ArrayList<>();
-
-        for (TextAnnotation ta : reader) {
-            counter.incrementCount("Sentences");
-            System.out.println(ta.getTokenizedText());
-
-            if (!ta.hasView(ViewNames.SRL_VERB))
-                continue;
-
-            PredicateArgumentView pav = (PredicateArgumentView) ta.getView(ViewNames.SRL_VERB);
-            List<Constituent> predicates2 = pav.getPredicates();
-            counter.incrementCount("Predicates", predicates2.size());
-            for (Constituent c : predicates2) {
-                predicates.add(c.getAttribute(PredicateArgumentView.LemmaIdentifier));
-            }
-
-        }
-
-        System.out.println((int) counter.getCount("Sentences") + " sentences");
-        System.out.println((int) counter.getCount("Predicates") + " predicates");
+    public String generateReport() {
+        throw new UnsupportedOperationException("ERROR: generateReport() Not yet implemented.");
     }
 
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/OntonotesReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/OntonotesReader.java
@@ -32,10 +32,9 @@ import java.util.Map;
  * are ignored.
  */
 public class OntonotesReader extends TextAnnotationReader {
+    private static Logger logger = LoggerFactory.getLogger(OntonotesReader.class);
     private List<TextAnnotation> textAnnotations;
     private int taCounter;
-
-    private static Logger logger = LoggerFactory.getLogger(OntonotesReader.class);
 
     public OntonotesReader(String ontonotesDirectory) {
         super(CorpusReaderConfigurator.buildResourceManager("Ontonotes", ontonotesDirectory));
@@ -361,4 +360,14 @@ public class OntonotesReader extends TextAnnotationReader {
         else
             return s;
     }
+
+    /**
+     * TODO: generate a human-readable report of annotations read from the source file (plus whatever
+     * other relevant statistics the user should know about).
+     */
+
+    public String generateReport() {
+        throw new UnsupportedOperationException("ERROR: generateReport() Not yet implemented.");
+    }
+
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/PennTreebankReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/PennTreebankReader.java
@@ -36,18 +36,14 @@ public class PennTreebankReader extends TextAnnotationReader {
     protected final String[] sections;
 
     protected final String combinedWSJHome;
-
+    private final String parseViewName;
     protected int currentSectionId;
-
     String[] currentSectionFiles;
     int currentFileId;
-
-    private ArrayList<String> lines;
     int currentLineId;
 
     int treeInFile;
-
-    private final String parseViewName;
+    private ArrayList<String> lines;
 
     /**
      * Reads all the sections of the combined annotation from penn treebank
@@ -223,4 +219,15 @@ public class PennTreebankReader extends TextAnnotationReader {
     }
 
     public void remove() {}
+
+
+    /**
+     * TODO: generate a human-readable report of annotations read from the source file (plus whatever
+     * other relevant statistics the user should know about).
+     */
+
+    public String generateReport() {
+        throw new UnsupportedOperationException("ERROR: generateReport() Not yet implemented.");
+    }
+
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/TextAnnotationReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/TextAnnotationReader.java
@@ -85,4 +85,12 @@ public abstract class TextAnnotationReader implements Iterable<TextAnnotation>,
         throw new UnsupportedOperationException();
     }
 
+
+    /**
+     * generate a human-readable report of annotations read from the source file (plus whatever
+     * other relevant statistics the user should know about).
+     */
+
+    abstract public String generateReport();
+
 }

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/XmlFragmentWhitespacingDocumentReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/XmlFragmentWhitespacingDocumentReader.java
@@ -83,9 +83,16 @@ public class XmlFragmentWhitespacingDocumentReader extends AbstractIncrementalCo
         numTextAnnotations = 0;
     }
 
+    @Override
+    public void reset() {
+        super.reset();
+        numFiles = 0;
+        numTextAnnotations = 0;
+    }
+
     /**
      * Exclude any files not possessing this extension.
-     * 
+     * TODO: make this configurable
      * @return the required file extension.
      */
     protected String getRequiredFileExtension() {

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
@@ -89,7 +89,6 @@ public class EREMentionRelationReader extends ERENerReader {
     /**
      * given an xml document containing relation markup and a view populated with mentions, generate
      * relations in that view.
-     *
      * @param doc XML document containing relation info
      * @param mentionView View to populate with relations
      */
@@ -109,13 +108,11 @@ public class EREMentionRelationReader extends ERENerReader {
      * read the relations from the gold standard xml and produce appropriate Relations linking
      * mention constituents in the view.
      *
-     *   <relations>
-     *     <relation id="r-1952" type="generalaffiliation" subtype="opra">
-     *       <relation_mention id="relm-56bd16d7_2_837" realis="true">
-     *         <rel_arg1 entity_id="ent-m.07t31" entity_mention_id="m-56bd16d7_2_159" role="org">congress</rel_arg1>
-     *         <rel_arg2 entity_id="ent-m.07wbk" entity_mention_id="m-56bd16d7_2_153" role="entity">republican</rel_arg2>
-     *       </relation_mention>
-     *     </relation>
+     * <relations> <relation id="r-1952" type="generalaffiliation" subtype="opra"> <relation_mention
+     * id="relm-56bd16d7_2_837" realis="true"> <rel_arg1 entity_id="ent-m.07t31"
+     * entity_mention_id="m-56bd16d7_2_159" role="org">congress</rel_arg1> <rel_arg2
+     * entity_id="ent-m.07wbk" entity_mention_id="m-56bd16d7_2_153"
+     * role="entity">republican</rel_arg2> </relation_mention> </relation>
      *
      * @param node the entity node, contains the more specific mentions of that entity.
      * @param view the span label view we will add the labels to.
@@ -202,7 +199,6 @@ public class EREMentionRelationReader extends ERENerReader {
      * Reports number of relations and relation mentions read from source and generated. Note that
      * number read and number generated may disagree because an argument was not read correctly (see
      * {#ERENerReader.generateReport()})
-     *
      * @return a String representing a human-readable report on information read from corpus and
      *         generated as data structures.
      */

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/EREMentionRelationReader.java
@@ -59,6 +59,18 @@ public class EREMentionRelationReader extends ERENerReader {
         numRelationMentionsGenerated = 0;
     }
 
+
+
+    @Override
+    public void reset() {
+        super.reset();
+        numRelationsInSource = 0;
+        numRelationsGenerated = 0;
+        numRelationMentionsInSource = 0;
+        numRelationMentionsGenerated = 0;
+    }
+
+    
     @Override
     public List<TextAnnotation> getTextAnnotationsFromFile(List<Path> corpusFileListEntry)
             throws Exception {

--- a/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
+++ b/corpusreaders/src/main/java/edu/illinois/cs/cogcomp/nlp/corpusreaders/ereReader/ERENerReader.java
@@ -73,8 +73,8 @@ public class ERENerReader extends EREDocumentReader {
     private int numEntitiesGenerated;
     private int numMentionsInSource;
     private int numMentionsGenerated;
-    private int numFillersInSource;
-    private int numFillersGenerated;
+//    private int numFillersInSource;
+//    private int numFillersGenerated;
 
 
     /**
@@ -101,6 +101,20 @@ public class ERENerReader extends EREDocumentReader {
 
         mentionIdToConstituent = new HashMap<>();
         entityIdToMentionIds = new HashMap<>();
+
+        this.numMentionsInSource = 0;
+        this.numMentionsGenerated = 0;
+        this.numEntitiesInSource = 0;
+        this.numEntitiesGenerated = 0;
+    }
+
+    @Override
+    public void reset() {
+        super.reset();
+        this.numMentionsInSource = 0;
+        this.numMentionsGenerated = 0;
+        this.numEntitiesInSource = 0;
+        this.numEntitiesGenerated = 0;
     }
 
     @Override
@@ -549,10 +563,10 @@ public class ERENerReader extends EREDocumentReader {
                 .append(System.lineSeparator());
         bldr.append("Number of entities generated: ").append(numEntitiesGenerated)
                 .append(System.lineSeparator());
-        bldr.append("Number of fillers in source: ").append(numFillersInSource)
-                .append(System.lineSeparator());
-        bldr.append("Number of fillers generated: ").append(numFillersGenerated)
-                .append(System.lineSeparator());
+//        bldr.append("Number of fillers in source: ").append(numFillersInSource)
+//                .append(System.lineSeparator());
+//        bldr.append("Number of fillers generated: ").append(numFillersGenerated)
+//                .append(System.lineSeparator());
         bldr.append("Number of mentions in source: ").append(numMentionsInSource)
                 .append(System.lineSeparator());
         bldr.append("Number of mentions generated: ").append(numMentionsGenerated)

--- a/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/common/PipelineConfigurator.java
+++ b/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/common/PipelineConfigurator.java
@@ -68,7 +68,8 @@ public class PipelineConfigurator extends AnnotatorConfigurator {
                         USE_SHALLOW_PARSE, USE_DEP, USE_NER_CONLL, USE_NER_ONTONOTES,
                         USE_STANFORD_PARSE, USE_STANFORD_DEP, USE_SRL_VERB, USE_SRL_NOM,
                         USE_QUANTIFIER, THROW_EXCEPTION_ON_FAILED_LENGTH_CHECK, USE_JSON,
-                        USE_LAZY_INITIALIZATION, USE_SRL_INTERNAL_PREPROCESSOR, SPLIT_ON_DASH};
+                        USE_LAZY_INITIALIZATION, USE_SRL_INTERNAL_PREPROCESSOR, SPLIT_ON_DASH,
+                        USE_SENTENCE_PIPELINE};
         return (new AnnotatorServiceConfigurator().getConfig(new ResourceManager(
                 generateProperties(properties))));
     }

--- a/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/SentencePipeline.java
+++ b/pipeline/src/main/java/edu/illinois/cs/cogcomp/pipeline/main/SentencePipeline.java
@@ -1,3 +1,10 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
 package edu.illinois.cs.cogcomp.pipeline.main;
 
 import edu.illinois.cs.cogcomp.annotation.*;

--- a/pipeline/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/SentencePipelineTest.java
+++ b/pipeline/src/test/java/edu/illinois/cs/cogcomp/pipeline/main/SentencePipelineTest.java
@@ -1,3 +1,10 @@
+/**
+ * This software is released under the University of Illinois/Research and Academic Use License. See
+ * the LICENSE file in the root folder for details. Copyright (c) 2016
+ *
+ * Developed by: The Cognitive Computation Group University of Illinois at Urbana-Champaign
+ * http://cogcomp.cs.illinois.edu/
+ */
 package edu.illinois.cs.cogcomp.pipeline.main;
 
 import edu.illinois.cs.cogcomp.annotation.AnnotatorException;


### PR DESCRIPTION
option to process TextAnnotations sentence-by-sentence. The goal is to allow more robust handling of documents -- catch exceptions for individual sentences, but continue processing afterwards. This may need some additional changes to specific handlers to throw appropriate exceptions, but this PR provides the basic pipeline behavior and an appropriate test.