### PR TITLE
[core-utils] addView exception handled

### DIFF
--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/BasicAnnotatorService.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/BasicAnnotatorService.java
@@ -371,7 +371,12 @@ public class BasicAnnotatorService implements AnnotatorService {
                 ta = annotationCache.getTextAnnotation(ta);
 
         for (String viewName : viewsToAnnotate) {
-            isUpdated = addView(ta, viewName) || isUpdated;
+            try {
+                isUpdated = addView(ta, viewName) || isUpdated;
+            } catch (AnnotatorException e) {
+                // the exception is handled here, because one single view failure should not resutl in loss of all the annotations
+                e.printStackTrace();
+            }
         }
 
         if (!disableCache && (isUpdated || forceUpdate) || clientForceUpdate) {

--- a/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/BasicAnnotatorService.java
+++ b/core-utilities/src/main/java/edu/illinois/cs/cogcomp/annotation/BasicAnnotatorService.java
@@ -375,6 +375,7 @@ public class BasicAnnotatorService implements AnnotatorService {
                 isUpdated = addView(ta, viewName) || isUpdated;
             } catch (AnnotatorException e) {
                 // the exception is handled here, because one single view failure should not resutl in loss of all the annotations
+                logger.error("The annotator for view " + viewName + " failed. Skipping the view . . . ");
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
Sometimes a single annotator fails, in which case we shouldn't lose the whole text-annotation and the rest of the views. So here I handled the exception thrown by a single `addView` functions of the annotators. 

